### PR TITLE
Expose Firebase token via env

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -19,4 +19,6 @@ jobs:
       - run: npm install -g firebase-tools
 
       - name: Deploy
-        run: firebase deploy --only hosting --token "$FIREBASE_TOKEN"
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: firebase deploy --only hosting


### PR DESCRIPTION
## Summary
- export the Firebase token secret into the Deploy step environment
- rely on the environment token so the deploy command no longer passes --token

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9d10813bc832e975fe9ea9fcdc8f2