### PR TITLE
Add Phaser shell with centered text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,28 @@
 <!doctype html>
-<html>
-<head>
-  <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">
-  <title>Stick-Fight — Coming Soon</title>
-  <style>body{margin:0;display:grid;place-items:center;height:100vh;font:16px system-ui;background:#111;color:#0ff}</style>
-</head>
-<body>
-  <main>
-    <h1>Stick-Fight</h1>
-    <p>If you can see this on BOTH phones, hosting works.</p>
-  </main>
-</body>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">
+    <title>Stick-Fight — Shell</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #000;
+        color: #fff;
+        overflow: hidden;
+        touch-action: none;
+      }
+      #game-root {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
+    <script src="main.js" defer></script>
+  </head>
+  <body>
+    <div id="game-root"></div>
+  </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,60 @@
+(function () {
+  const preventDefaultScroll = (event) => {
+    if (event.touches && event.touches.length > 1) {
+      return;
+    }
+    event.preventDefault();
+  };
+
+  document.body.addEventListener('touchmove', preventDefaultScroll, { passive: false });
+
+  class ShellScene extends Phaser.Scene {
+    constructor() {
+      super({ key: 'ShellScene' });
+      this.centerText = null;
+    }
+
+    preload() {}
+
+    create() {
+      this.cameras.main.setBackgroundColor('#000000');
+      this.centerText = this.add.text(0, 0, 'Stick-Fight (Shell)', {
+        fontFamily: 'Arial, sans-serif',
+        fontSize: '48px',
+        color: '#ffffff',
+      }).setOrigin(0.5, 0.5);
+
+      this.scale.on('resize', this.handleResize, this);
+      const { width, height } = this.scale.gameSize;
+      this.handleResize({ width, height });
+    }
+
+    handleResize(gameSize) {
+      const { width, height } = gameSize;
+      const camera = this.cameras.main;
+      camera.setViewport(0, 0, width, height);
+      this.centerText.setPosition(width / 2, height / 2);
+    }
+
+    update() {}
+  }
+
+  const config = {
+    type: Phaser.AUTO,
+    parent: 'game-root',
+    backgroundColor: '#000000',
+    scale: {
+      mode: Phaser.Scale.RESIZE,
+      autoCenter: Phaser.Scale.CENTER_BOTH,
+    },
+    scene: ShellScene,
+  };
+
+  window.addEventListener('load', () => {
+    const game = new Phaser.Game(config);
+
+    window.addEventListener('resize', () => {
+      game.scale.resize(window.innerWidth, window.innerHeight);
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- replace the placeholder HTML with a minimal shell that loads Phaser 3 from a CDN and hosts the game canvas
- add a Phaser scene that centers "Stick-Fight (Shell)" text on a black, resize-aware viewport and disables touch scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9d3c686cc832e8e35f212abe6ddec