### PR TITLE
Add MainScene bootstrap for Phaser app

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -8,46 +8,81 @@
 
   document.body.addEventListener('touchmove', preventDefaultScroll, { passive: false });
 
-  class ShellScene extends Phaser.Scene {
+  const centerText = (scene, content, offsetY = 0, style = {}) => {
+    const textStyle = {
+      fontFamily: 'Arial, sans-serif',
+      fontSize: '48px',
+      color: '#ffffff',
+      align: 'center',
+      ...style,
+    };
+
+    const text = scene.add.text(0, 0, content, textStyle).setOrigin(0.5, 0.5);
+
+    const updatePosition = () => {
+      const { width, height } = scene.scale.gameSize;
+      text.setPosition(width / 2, height / 2 + offsetY);
+    };
+
+    updatePosition();
+
+    if (!scene._centeredElements) {
+      scene._centeredElements = [];
+    }
+    scene._centeredElements.push(updatePosition);
+
+    return text;
+  };
+
+  class MainScene extends Phaser.Scene {
     constructor() {
-      super({ key: 'ShellScene' });
-      this.centerText = null;
+      super({ key: 'MainScene' });
+      this.dt = 0;
+      this._centeredElements = [];
     }
 
     preload() {}
 
     create() {
-      this.cameras.main.setBackgroundColor('#000000');
-      this.centerText = this.add.text(0, 0, 'Stick-Fight (Shell)', {
-        fontFamily: 'Arial, sans-serif',
-        fontSize: '48px',
-        color: '#ffffff',
-      }).setOrigin(0.5, 0.5);
+      this.cameras.main.setBackgroundColor('#111');
+
+      centerText(this, 'Stick-Fight', -28, { fontSize: '56px', fontStyle: '700' });
+      centerText(this, 'Main Scene Ready', 28, { fontSize: '24px', color: '#bbbbbb' });
 
       this.scale.on('resize', this.handleResize, this);
-      const { width, height } = this.scale.gameSize;
-      this.handleResize({ width, height });
+      this.handleResize(this.scale.gameSize);
     }
 
     handleResize(gameSize) {
-      const { width, height } = gameSize;
+      const { width, height } = gameSize || this.scale.gameSize;
       const camera = this.cameras.main;
       camera.setViewport(0, 0, width, height);
-      this.centerText.setPosition(width / 2, height / 2);
+      camera.centerOn(width / 2, height / 2);
+
+      (this._centeredElements || []).forEach((updatePosition) => updatePosition());
     }
 
-    update() {}
+    update(time, delta) {
+      this.dt = Math.min(delta, 50) / 1000;
+    }
   }
 
   const config = {
     type: Phaser.AUTO,
     parent: 'game-root',
-    backgroundColor: '#000000',
+    backgroundColor: '#111',
+    physics: {
+      default: 'arcade',
+      arcade: {
+        gravity: { y: 0 },
+        debug: false,
+      },
+    },
     scale: {
       mode: Phaser.Scale.RESIZE,
       autoCenter: Phaser.Scale.CENTER_BOTH,
     },
-    scene: ShellScene,
+    scene: [MainScene],
   };
 
   window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- add a reusable centerText helper for consistent positioning across resizes
- implement a Phaser MainScene with preload, create, and update methods
- configure the game bootstrap with arcade physics, resize handling, and background color updates

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9d5c11f28832e932e69592ad1fa27