### PR TITLE
NET-02: Firestore signaling + WebRTC DataChannels (host/guest)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,8 @@
       }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.7.2/firebase-app-compat.js" defer></script>
+    <script src="https://www.gstatic.com/firebasejs/10.7.2/firebase-firestore-compat.js" defer></script>
     <script src="joydiag-config.js" defer></script>
     <script src="main.js" defer></script>
   </head>


### PR DESCRIPTION
## Summary
- add Firestore-backed signaling utilities, peer connection factory, and WebRTC data channel setup with diagnostics hooks
- integrate networking lifecycle into the main scene, including session resolution, overlay diagnostics, and cleanup routines
- load Firebase compat scripts so the client can bootstrap Firestore signaling

## Testing
- node --test tests/joydiag-config.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ca60f8a25c832eb129028aedb54d8c