### PR TITLE
Add host-side player registry and peer input handling

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -128,6 +128,7 @@
   })();
 
   const NET_DIAG_ENABLED = !!NET_QUERY_PARAMS.netdiag;
+  const NET_INPUT_STALE_MS = 1500;
 
   function netDiagLog(tag, payload) {
     if (!NET_DIAG_ENABLED) {
@@ -2875,6 +2876,8 @@ this.teardownNetworking && this.teardownNetworking();
     createNetState(role) {
       this.net = {
         role: role,
+        roomId: null,
+        peerId: null,
         pcMap: {},
         dcMap: {},
         inputDc: null,
@@ -2882,6 +2885,8 @@ this.teardownNetworking && this.teardownNetworking();
         rtts: {},
         lastOfferTs: null,
         lastAnswerTs: null,
+        peerInputs: {},
+        players: {},
       };
     }
 
@@ -2905,6 +2910,15 @@ this.teardownNetworking && this.teardownNetworking();
       }
 
       this.createNetState(session.isHost ? 'host' : 'guest');
+      if (this.net) {
+        this.net.roomId = session.roomId;
+        this.net.peerId = session.peerId;
+        this.net.peerInputs = {};
+        this.net.players = {};
+      }
+      if (session.isHost && typeof this.onNetPeerJoined === 'function') {
+        this.onNetPeerJoined(session.peerId, { isLocal: true });
+      }
 
       const signaling = new Signaling({
         db: db,
@@ -2948,6 +2962,10 @@ this.teardownNetworking && this.teardownNetworking();
         this.net.rtts = {};
         this.net.lastOfferTs = null;
         this.net.lastAnswerTs = null;
+        this.net.peerInputs = {};
+        this.net.players = {};
+        this.net.peerId = null;
+        this.net.roomId = null;
       }
       this.net = null;
       this.updateNetOverlay();
@@ -3512,10 +3530,241 @@ if (typeof this.positionNetDiagOverlay === 'function') {
 
       this.updateDebugOverlay();
       this.updateNetOverlay();
+      if (this.net && this.net.role === 'host' && typeof this.serverFixedStep === 'function') {
+        this.serverFixedStep(this.dt);
+      }
       traceControls(this);
 
       if (this._joyDiagFrameState) {
         this.flushJoyDiagFrameDiagnostics();
+      }
+    }
+
+    getNetTimestamp() {
+      if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+        return performance.now();
+      }
+      return Date.now();
+    }
+
+    createDefaultNetInput() {
+      return { moveX: 0, crouch: false, punch: false, kick: false, jump: 0 };
+    }
+
+    normalizePeerInputPacket(packet) {
+      if (!packet || typeof packet !== 'object') {
+        const defaults = this.createDefaultNetInput();
+        return Object.assign(
+          { receivedAt: this.getNetTimestamp(), sequence: null, timestamp: null, packetStale: false },
+          defaults
+        );
+      }
+      const payload = packet.payload && typeof packet.payload === 'object' ? packet.payload : null;
+      const inputPayload = payload && typeof payload.p === 'object' ? payload.p : null;
+      const defaults = this.createDefaultNetInput();
+      const moveX = inputPayload && typeof inputPayload.mx !== 'undefined'
+        ? Phaser.Math.Clamp(Number(inputPayload.mx) || 0, -1, 1)
+        : defaults.moveX;
+      const crouch = inputPayload && typeof inputPayload.cr !== 'undefined'
+        ? !!inputPayload.cr
+        : defaults.crouch;
+      const punch = inputPayload && typeof inputPayload.pu !== 'undefined'
+        ? !!inputPayload.pu
+        : defaults.punch;
+      const kick = inputPayload && typeof inputPayload.ki !== 'undefined'
+        ? !!inputPayload.ki
+        : defaults.kick;
+      const rawJump = inputPayload && typeof inputPayload.ju === 'number' ? inputPayload.ju : defaults.jump;
+      const jump = Phaser.Math.Clamp(Math.round(rawJump), -1, 1);
+      const receivedAt =
+        typeof packet.receivedAt === 'number' && Number.isFinite(packet.receivedAt)
+          ? packet.receivedAt
+          : this.getNetTimestamp();
+      const sequence =
+        payload && typeof payload.seq === 'number' && Number.isFinite(payload.seq)
+          ? payload.seq
+          : null;
+      const timestamp =
+        payload && typeof payload.t === 'number' && Number.isFinite(payload.t)
+          ? payload.t
+          : null;
+
+      return {
+        moveX,
+        crouch,
+        punch,
+        kick,
+        jump,
+        receivedAt,
+        sequence,
+        timestamp,
+        packetStale: !!packet.stale,
+      };
+    }
+
+    computeNetSpawnPosition(index) {
+      const worldBounds =
+        this.physics && this.physics.world && this.physics.world.bounds
+          ? this.physics.world.bounds
+          : null;
+      const area = worldBounds
+        ? { x: worldBounds.x, y: worldBounds.y, w: worldBounds.width, h: worldBounds.height }
+        : this.playArea || { x: 0, y: 0, w: 0, h: 0 };
+      const marginX = 64;
+      const marginY = 72;
+      const width = Math.max(typeof area.w === 'number' ? area.w : 0, marginX * 2 + 1);
+      const height = Math.max(typeof area.h === 'number' ? area.h : 0, marginY * 2 + 1);
+      const safeLeft = area.x + marginX;
+      const safeRight = area.x + width - marginX;
+      const safeBottom = area.y + height - marginY;
+      const centerX = area.x + width * 0.5;
+      const offset = (index % 4) - 1.5;
+      const spacing = 120;
+      const spawnX = Phaser.Math.Clamp(centerX + offset * spacing, safeLeft, safeRight);
+      const spawnY = Phaser.Math.Clamp(safeBottom, area.y + marginY, area.y + height - marginY);
+      return { x: spawnX, y: spawnY };
+    }
+
+    onNetPeerJoined(peerId, meta) {
+      if (!this.net || this.net.role !== 'host') {
+        return;
+      }
+      if (typeof peerId !== 'string' || peerId.length === 0) {
+        return;
+      }
+      if (!this.net.players) {
+        this.net.players = {};
+      }
+      if (this.net.players[peerId]) {
+        return;
+      }
+      const index = Object.keys(this.net.players).length;
+      const spawn = this.computeNetSpawnPosition(index);
+      const centerX = this.playArea ? this.playArea.x + this.playArea.w * 0.5 : spawn.x;
+      const facing = spawn.x < centerX ? 1 : -1;
+      const record = {
+        id: peerId,
+        x: spawn.x,
+        y: spawn.y,
+        vx: 0,
+        vy: 0,
+        hp: 100,
+        facing,
+        onGround: true,
+        lastInputAt: null,
+        lastKnownInput: null,
+        inputStale: false,
+        lastPacketStale: false,
+        packetTimestamp: null,
+        packetSequence: null,
+        lastProcessedAt: null,
+      };
+      this.net.players[peerId] = record;
+      if (!this.net.peerInputs) {
+        this.net.peerInputs = {};
+      }
+      if (!meta || !meta.skipLog) {
+        console.log('[Net] Registered player', peerId, record);
+      }
+    }
+
+    onNetPeerLeft(peerId) {
+      if (!this.net || !this.net.players) {
+        return;
+      }
+      if (typeof peerId !== 'string' || peerId.length === 0) {
+        return;
+      }
+      if (this.net.players[peerId]) {
+        delete this.net.players[peerId];
+        if (this.net.peerInputs) {
+          delete this.net.peerInputs[peerId];
+        }
+        console.log('[Net] Removed player', peerId);
+      }
+    }
+
+    onPeerInput(peerId, packet) {
+      if (!this.net || this.net.role !== 'host') {
+        return;
+      }
+      if (typeof peerId !== 'string' || peerId.length === 0) {
+        return;
+      }
+      const normalized = this.normalizePeerInputPacket(packet);
+      if (!this.net.peerInputs) {
+        this.net.peerInputs = {};
+      }
+      this.net.peerInputs[peerId] = normalized;
+      const record = this.net.players ? this.net.players[peerId] : null;
+      if (record) {
+        record.lastPacketStale = !!normalized.packetStale;
+      }
+    }
+
+    serverFixedStep(dt) {
+      if (!this.net || this.net.role !== 'host') {
+        return;
+      }
+      const players = this.net.players || {};
+      const now = this.getNetTimestamp();
+      const playerIds = Object.keys(players);
+      for (let i = 0; i < playerIds.length; i += 1) {
+        const peerId = playerIds[i];
+        if (!peerId || peerId === this.net.peerId) {
+          continue;
+        }
+        const player = players[peerId];
+        if (!player) {
+          continue;
+        }
+        const defaults = this.createDefaultNetInput();
+        const incoming = this.net.peerInputs ? this.net.peerInputs[peerId] : null;
+        if (incoming) {
+          const applied = Object.assign({}, defaults, incoming);
+          const packetMarkedStale = !!applied.packetStale;
+          player.packetTimestamp = typeof applied.timestamp === 'number' ? applied.timestamp : null;
+          player.packetSequence = typeof applied.sequence === 'number' ? applied.sequence : null;
+          delete this.net.peerInputs[peerId];
+          if (packetMarkedStale) {
+            if (!player.lastPacketStale) {
+              console.warn(`[Net] Player ${peerId} packet stale (timestamp drift)`);
+            }
+            player.lastPacketStale = true;
+            player.inputStale = true;
+            player.lastInputAt = now - (NET_INPUT_STALE_MS + 1);
+            player.activeInput = Object.assign({}, defaults);
+            player.lastProcessedAt = now;
+            continue;
+          }
+          player.lastPacketStale = false;
+          player.lastKnownInput = applied;
+          player.lastInputAt =
+            typeof applied.receivedAt === 'number' && Number.isFinite(applied.receivedAt)
+              ? applied.receivedAt
+              : now;
+        }
+        if (!player.lastKnownInput) {
+          player.activeInput = Object.assign({}, defaults);
+          player.inputStale = false;
+          continue;
+        }
+        const ageMs = typeof player.lastInputAt === 'number' ? now - player.lastInputAt : null;
+        const isStale = Number.isFinite(ageMs) && ageMs > NET_INPUT_STALE_MS;
+        if (isStale) {
+          if (!player.inputStale) {
+            console.warn(`[Net] Player ${peerId} input stale (${Math.round(ageMs)}ms)`);
+          }
+          player.inputStale = true;
+          player.activeInput = Object.assign({}, defaults);
+        } else {
+          if (player.inputStale) {
+            console.log(`[Net] Player ${peerId} input active`);
+          }
+          player.inputStale = false;
+          player.activeInput = Object.assign({}, defaults, player.lastKnownInput);
+        }
+        player.lastProcessedAt = now;
       }
     }
 

--- a/public/netplay.js
+++ b/public/netplay.js
@@ -264,6 +264,17 @@
           const name = data.name || 'Player';
           if (change.type === 'removed') {
             removePlayerFromDirectory(peerId);
+            if (
+              runtime.role === 'host' &&
+              runtime.scene &&
+              typeof runtime.scene.onNetPeerLeft === 'function'
+            ) {
+              try {
+                runtime.scene.onNetPeerLeft(peerId);
+              } catch (err) {
+                console.warn('[Net] Failed to notify scene of peer removal', err);
+              }
+            }
             if (runtime.role === 'host') {
               teardownConnection(peerId);
             }
@@ -272,6 +283,18 @@
           updatePlayerDirectory(peerId, name);
           if (runtime.role === 'host' && peerId !== runtime.localPeerId) {
             ensureHostConnection(peerId);
+          }
+          if (
+            change.type === 'added' &&
+            runtime.role === 'host' &&
+            runtime.scene &&
+            typeof runtime.scene.onNetPeerJoined === 'function'
+          ) {
+            try {
+              runtime.scene.onNetPeerJoined(peerId, { isLocal: peerId === runtime.localPeerId });
+            } catch (err) {
+              console.warn('[Net] Failed to notify scene of peer join', err);
+            }
           }
           if (!runtime.slotAssignments.p1 && data.isHost) {
             runtime.slotAssignments.p1 = peerId;
@@ -518,6 +541,17 @@
         receivedAt: now,
         stale: typeof payload.t === 'number' ? now - payload.t > INPUT_STALE_MS : false,
       };
+      if (
+        runtime.role === 'host' &&
+        runtime.scene &&
+        typeof runtime.scene.onPeerInput === 'function'
+      ) {
+        try {
+          runtime.scene.onPeerInput(peerId, runtime.peerInputs[peerId]);
+        } catch (err) {
+          console.warn('[Net] Scene peer input handling failed', err);
+        }
+      }
       connection.lastInputReceivedAt = now;
       runtime.lastInputReceivedAt = now;
       const moveX = clamp(Number(payload.p.mx) || 0, -1, 1);


### PR DESCRIPTION
## Summary
- extend the host net state to track players and peer input buffers when sessions start and end
- notify the scene when peers join, leave, or send input so the host can keep its registry in sync
- add host-side input normalization and serverFixedStep processing that logs stale peers and tracks activity timestamps

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ca6fcb9ad4832e93e82d2f92364e3e