### PR TITLE
Implement host server movement and physics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,10 +54,12 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js" defer></script>
     <script src="joydiag-config.js" defer></script>
     <script src="net.js" defer></script>
+    <script src="net-server.js" defer></script>
     <script src="netplay.js" defer></script>
     <script src="main.js" defer></script>
     <script src="joydiag-config.js" defer></script>
     <script src="net.js" defer></script>
+    <script src="net-server.js" defer></script>
     <script src="main.js" defer></script>
   </head>
   <body>

--- a/public/net-server.js
+++ b/public/net-server.js
@@ -1,0 +1,361 @@
+(function (global) {
+  'use strict';
+
+  const SPEED = 220;
+  const ACCEL = 1200;
+  const FRICTION = 1600;
+  const JUMP_V = 560;
+  const GRAVITY = 2200;
+  const HALF_WIDTH = 14;
+  const HALF_HEIGHT = 32;
+  const DEFAULT_PLAY_RECT = { x: 0, y: 0, width: 960, height: 540 };
+  const JUMP_IMPULSE = SPEED * 0.35;
+
+  function clamp(value, min, max) {
+    if (!Number.isFinite(value)) {
+      return min;
+    }
+    if (value < min) {
+      return min;
+    }
+    if (value > max) {
+      return max;
+    }
+    return value;
+  }
+
+  function normalizePlayRect(rect) {
+    if (!rect || typeof rect !== 'object') {
+      return { x: DEFAULT_PLAY_RECT.x, y: DEFAULT_PLAY_RECT.y, width: DEFAULT_PLAY_RECT.width, height: DEFAULT_PLAY_RECT.height };
+    }
+    const width = Number(rect.width !== undefined ? rect.width : rect.w);
+    const height = Number(rect.height !== undefined ? rect.height : rect.h);
+    const resolvedWidth = Number.isFinite(width) && width > HALF_WIDTH * 2 ? width : DEFAULT_PLAY_RECT.width;
+    const resolvedHeight = Number.isFinite(height) && height > HALF_HEIGHT * 2 ? height : DEFAULT_PLAY_RECT.height;
+    const x = Number(rect.x);
+    const y = Number(rect.y);
+    return {
+      x: Number.isFinite(x) ? x : DEFAULT_PLAY_RECT.x,
+      y: Number.isFinite(y) ? y : DEFAULT_PLAY_RECT.y,
+      width: resolvedWidth,
+      height: resolvedHeight,
+    };
+  }
+
+  function createDefaultSpawnPoints(playRect) {
+    const floorY = playRect.y + playRect.height - HALF_HEIGHT;
+    return [
+      { x: playRect.x + playRect.width * 0.22, y: floorY, facing: 1 },
+      { x: playRect.x + playRect.width * 0.78, y: floorY, facing: -1 },
+    ];
+  }
+
+  function normalizeSpawn(spawn, playRect, defaultFacing) {
+    const fallbackX = playRect.x + playRect.width * 0.5;
+    const fallbackY = playRect.y + playRect.height - HALF_HEIGHT;
+    let facing = defaultFacing;
+    if (!Number.isFinite(facing) || facing === 0) {
+      facing = 1;
+    }
+    if (!spawn || typeof spawn !== 'object') {
+      return { x: fallbackX, y: fallbackY, facing };
+    }
+    const x = Number(spawn.x);
+    const y = Number(spawn.y);
+    const providedFacing = Number(spawn.facing);
+    if (Number.isFinite(providedFacing) && providedFacing !== 0) {
+      facing = providedFacing > 0 ? 1 : -1;
+    }
+    return {
+      x: Number.isFinite(x) ? x : fallbackX,
+      y: Number.isFinite(y) ? y : fallbackY,
+      facing,
+    };
+  }
+
+  function computeSpawnPoints(spawnList, playRect) {
+    const defaults = createDefaultSpawnPoints(playRect);
+    if (!Array.isArray(spawnList) || spawnList.length === 0) {
+      return defaults;
+    }
+    return spawnList.map((spawn, index) => {
+      const fallback = defaults[index % defaults.length];
+      const fallbackFacing = fallback ? fallback.facing : index % 2 === 0 ? 1 : -1;
+      return normalizeSpawn(spawn, playRect, fallbackFacing);
+    });
+  }
+
+  function clonePlayer(player) {
+    return {
+      id: player.id,
+      slot: player.slot || null,
+      name: player.name || 'Player',
+      x: player.x,
+      y: player.y,
+      vx: player.vx,
+      vy: player.vy,
+      onGround: !!player.onGround,
+      facing: player.facing || 1,
+      halfWidth: player.halfWidth,
+      halfHeight: player.halfHeight,
+    };
+  }
+
+  function normalizeInput(input) {
+    if (!input || typeof input !== 'object') {
+      return { mx: 0, ju: 0 };
+    }
+    const mx = clamp(Number(input.mx !== undefined ? input.mx : input.moveX) || 0, -1, 1);
+    let ju = Number(input.ju !== undefined ? input.ju : input.jumpDirection);
+    if (!Number.isFinite(ju)) {
+      if (input.jumpForward) {
+        ju = 1;
+      } else if (input.jumpBack) {
+        ju = -1;
+      } else {
+        ju = 0;
+      }
+    }
+    ju = Math.max(-1, Math.min(1, Math.trunc(ju)));
+    return { mx, ju };
+  }
+
+  function clampPlayerToPlayRect(player, playRect) {
+    const minX = playRect.x + player.halfWidth;
+    const maxX = playRect.x + playRect.width - player.halfWidth;
+    const minY = playRect.y + player.halfHeight;
+    const maxY = playRect.y + playRect.height - player.halfHeight;
+
+    if (player.x < minX) {
+      player.x = minX;
+      if (player.vx < 0) {
+        player.vx = 0;
+      }
+    } else if (player.x > maxX) {
+      player.x = maxX;
+      if (player.vx > 0) {
+        player.vx = 0;
+      }
+    }
+
+    if (player.y < minY) {
+      player.y = minY;
+      if (player.vy < 0) {
+        player.vy = 0;
+      }
+    }
+
+    if (player.y >= maxY) {
+      player.y = maxY;
+      if (player.vy > 0) {
+        player.vy = 0;
+      }
+      player.onGround = true;
+    } else if (player.vy !== 0) {
+      player.onGround = false;
+    }
+  }
+
+  function updateFacing(players) {
+    if (!players || players.length < 2) {
+      return;
+    }
+    for (let i = 0; i < players.length; i += 1) {
+      const player = players[i];
+      let nearest = null;
+      let nearestDistance = Infinity;
+      for (let j = 0; j < players.length; j += 1) {
+        if (i === j) {
+          continue;
+        }
+        const other = players[j];
+        const distance = Math.abs(other.x - player.x);
+        if (distance < nearestDistance) {
+          nearestDistance = distance;
+          nearest = other;
+        }
+      }
+      if (nearest) {
+        const delta = nearest.x - player.x;
+        player.facing = delta >= 0 ? 1 : -1;
+      }
+    }
+  }
+
+  function serverFixedStep(registry, dt) {
+    if (!registry || !Number.isFinite(dt) || dt <= 0) {
+      return;
+    }
+    const players = Array.from(registry.players.values());
+    const playRect = registry.playRect;
+    for (let i = 0; i < players.length; i += 1) {
+      const player = players[i];
+      const input = registry.inputs.get(player.id) || { mx: 0, ju: 0 };
+      const moveInput = clamp(input.mx || 0, -1, 1);
+      const targetVx = moveInput * SPEED;
+      if (targetVx > player.vx) {
+        player.vx = Math.min(player.vx + ACCEL * dt, targetVx);
+      } else if (targetVx < player.vx) {
+        player.vx = Math.max(player.vx - ACCEL * dt, targetVx);
+      } else if (targetVx === 0 && player.onGround) {
+        const frictionStep = FRICTION * dt;
+        if (player.vx > frictionStep) {
+          player.vx -= frictionStep;
+        } else if (player.vx < -frictionStep) {
+          player.vx += frictionStep;
+        } else {
+          player.vx = 0;
+        }
+      }
+
+      const jumpDir = input.ju || 0;
+      if (jumpDir !== 0 && player.onGround) {
+        player.vy = -JUMP_V;
+        player.onGround = false;
+        player.vx += jumpDir * JUMP_IMPULSE;
+      }
+
+      player.x += player.vx * dt;
+      player.vy += GRAVITY * dt;
+      player.y += player.vy * dt;
+
+      clampPlayerToPlayRect(player, playRect);
+    }
+
+    updateFacing(players);
+  }
+
+  function createRegistry(options) {
+    const opts = options && typeof options === 'object' ? options : {};
+    const registry = {
+      playRect: normalizePlayRect(opts.playRect),
+      baseSpawnPoints: Array.isArray(opts.spawnPoints) ? opts.spawnPoints.slice() : null,
+      spawnPoints: [],
+      players: new Map(),
+      inputs: new Map(),
+    };
+
+    registry.spawnPoints = computeSpawnPoints(registry.baseSpawnPoints, registry.playRect);
+
+    registry.ensurePlayer = function ensurePlayer(id, info) {
+      if (typeof id !== 'string' || !id) {
+        return null;
+      }
+      const existing = registry.players.get(id);
+      if (existing) {
+        if (info && typeof info === 'object') {
+          if (typeof info.name === 'string' && info.name.trim()) {
+            existing.name = info.name.trim();
+          }
+          if (typeof info.slot === 'string' && !existing.slot) {
+            existing.slot = info.slot;
+          }
+        }
+        return existing;
+      }
+
+      const details = info && typeof info === 'object' ? info : {};
+      const slot = typeof details.slot === 'string' ? details.slot : null;
+
+      let spawn = details.spawn;
+      if (!spawn) {
+        if (slot === 'p1' && registry.spawnPoints.length > 0) {
+          spawn = registry.spawnPoints[0];
+        } else if (slot === 'p2' && registry.spawnPoints.length > 1) {
+          spawn = registry.spawnPoints[1];
+        } else {
+          const index = registry.players.size % registry.spawnPoints.length;
+          spawn = registry.spawnPoints[index] || registry.spawnPoints[0];
+        }
+      }
+      spawn = normalizeSpawn(spawn, registry.playRect, spawn && spawn.facing ? spawn.facing : 1);
+
+      const player = {
+        id,
+        slot,
+        name: typeof details.name === 'string' && details.name.trim() ? details.name.trim() : 'Player',
+        x: spawn.x,
+        y: spawn.y,
+        vx: 0,
+        vy: 0,
+        onGround: true,
+        facing: spawn.facing || 1,
+        halfWidth: Number.isFinite(details.halfWidth) ? details.halfWidth : HALF_WIDTH,
+        halfHeight: Number.isFinite(details.halfHeight) ? details.halfHeight : HALF_HEIGHT,
+      };
+
+      registry.players.set(id, player);
+      registry.inputs.set(id, { mx: 0, ju: 0 });
+      clampPlayerToPlayRect(player, registry.playRect);
+      return player;
+    };
+
+    registry.removePlayer = function removePlayer(id) {
+      if (typeof id !== 'string') {
+        return false;
+      }
+      registry.inputs.delete(id);
+      return registry.players.delete(id);
+    };
+
+    registry.setInput = function setInput(id, input) {
+      if (typeof id !== 'string') {
+        return;
+      }
+      const normalized = normalizeInput(input);
+      registry.inputs.set(id, normalized);
+    };
+
+    registry.fixedStep = function fixedStep(dt) {
+      serverFixedStep(registry, dt);
+    };
+
+    registry.getPlayer = function getPlayer(id) {
+      const player = registry.players.get(id);
+      return player ? clonePlayer(player) : null;
+    };
+
+    registry.getPlayers = function getPlayers() {
+      return Array.from(registry.players.values()).map(clonePlayer);
+    };
+
+    registry.setPlayRect = function setPlayRect(rect) {
+      registry.playRect = normalizePlayRect(rect);
+      registry.spawnPoints = computeSpawnPoints(registry.baseSpawnPoints, registry.playRect);
+      registry.players.forEach((player) => {
+        clampPlayerToPlayRect(player, registry.playRect);
+      });
+    };
+
+    return registry;
+  }
+
+  const api = {
+    SPEED,
+    ACCEL,
+    FRICTION,
+    JUMP_V,
+    GRAVITY,
+    createRegistry,
+    serverFixedStep,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  if (global && typeof global === 'object') {
+    const existing = global.StickFightHostServer && typeof global.StickFightHostServer === 'object'
+      ? global.StickFightHostServer
+      : {};
+    existing.SPEED = SPEED;
+    existing.ACCEL = ACCEL;
+    existing.FRICTION = FRICTION;
+    existing.JUMP_V = JUMP_V;
+    existing.GRAVITY = GRAVITY;
+    existing.createRegistry = createRegistry;
+    existing.serverFixedStep = serverFixedStep;
+    global.StickFightHostServer = existing;
+  }
+})(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : this);
+

--- a/public/netplay.js
+++ b/public/netplay.js
@@ -25,6 +25,7 @@
     connections: new Map(),
     peerInputs: {},
     remotePlayers: [],
+    registry: null,
     lastInputSentAt: null,
     lastInputReceivedAt: null,
     lastStateBroadcastAt: null,
@@ -34,6 +35,7 @@
     guestSessionUnsub: null,
     guestCandidateUnsub: null,
     stateBroadcastTimer: null,
+    serverStepTimer: null,
   };
 
   function detectDiagnosticsFlag() {
@@ -72,6 +74,177 @@
     return value;
   }
 
+  const SERVER_FIXED_STEP_DT = 1 / 60;
+  const SERVER_FIXED_STEP_MS = 1000 / 60;
+
+  function getHostServerModule() {
+    const server = global.StickFightHostServer;
+    if (!server || typeof server.createRegistry !== 'function') {
+      return null;
+    }
+    return server;
+  }
+
+  function determinePlayRect() {
+    const scene = runtime.scene;
+    if (!scene || !scene.playArea) {
+      return null;
+    }
+    const play = scene.playArea;
+    const width = Number(play.w !== undefined ? play.w : play.width);
+    const height = Number(play.h !== undefined ? play.h : play.height);
+    if (!Number.isFinite(width) || !Number.isFinite(height)) {
+      return null;
+    }
+    const x = Number(play.x);
+    const y = Number(play.y);
+    return {
+      x: Number.isFinite(x) ? x : 0,
+      y: Number.isFinite(y) ? y : 0,
+      width,
+      height,
+    };
+  }
+
+  function getSlotForPeer(peerId) {
+    if (!peerId || !runtime.slotAssignments) {
+      return null;
+    }
+    const entries = Object.keys(runtime.slotAssignments);
+    for (let i = 0; i < entries.length; i += 1) {
+      const slot = entries[i];
+      if (runtime.slotAssignments[slot] === peerId) {
+        return slot;
+      }
+    }
+    return null;
+  }
+
+  function ensureHostRegistry() {
+    if (runtime.role !== 'host') {
+      return null;
+    }
+    const server = getHostServerModule();
+    if (!server) {
+      return null;
+    }
+    if (!runtime.registry || typeof runtime.registry.ensurePlayer !== 'function') {
+      const playRect = determinePlayRect();
+      runtime.registry = server.createRegistry(playRect ? { playRect } : {});
+    }
+    if (runtime.registry && typeof runtime.registry.setPlayRect === 'function') {
+      const playRect = determinePlayRect();
+      if (playRect) {
+        runtime.registry.setPlayRect(playRect);
+      }
+    }
+    return runtime.registry;
+  }
+
+  function ensureHostServerPlayer(peerId) {
+    if (!peerId || runtime.role !== 'host') {
+      return;
+    }
+    const registry = ensureHostRegistry();
+    if (!registry || typeof registry.ensurePlayer !== 'function') {
+      return;
+    }
+    registry.ensurePlayer(peerId, { slot: getSlotForPeer(peerId), name: getPlayerName(peerId) });
+  }
+
+  function updateRegistryPlayerName(peerId, name) {
+    if (!peerId || runtime.role !== 'host') {
+      return;
+    }
+    const registry = ensureHostRegistry();
+    if (!registry || typeof registry.ensurePlayer !== 'function') {
+      return;
+    }
+    registry.ensurePlayer(peerId, { slot: getSlotForPeer(peerId), name });
+  }
+
+  function normalizePeerInput(payload) {
+    if (!payload || typeof payload !== 'object') {
+      return { mx: 0, ju: 0 };
+    }
+    const move = clamp(Number(payload.mx !== undefined ? payload.mx : payload.moveX) || 0, -1, 1);
+    let jump = Number(payload.ju);
+    if (!Number.isFinite(jump)) {
+      jump = 0;
+    }
+    if (jump > 1) {
+      jump = 1;
+    } else if (jump < -1) {
+      jump = -1;
+    } else {
+      jump = Math.trunc(jump);
+    }
+    return { mx: move, ju: jump };
+  }
+
+  function readLocalInput() {
+    if (!runtime.scene || typeof runtime.scene.getPlayerInput !== 'function') {
+      return { mx: 0, ju: 0 };
+    }
+    const state = runtime.scene.getPlayerInput(runtime.localSlot);
+    if (!state) {
+      return { mx: 0, ju: 0 };
+    }
+    const move = clamp(Number(state.moveX) || 0, -1, 1);
+    let jumpDir = 0;
+    if (state.jumpForward) {
+      jumpDir = 1;
+    } else if (state.jumpBack) {
+      jumpDir = -1;
+    }
+    return { mx: move, ju: jumpDir };
+  }
+
+  function stepHostServer(dtOverride) {
+    if (runtime.role !== 'host') {
+      return;
+    }
+    const registry = ensureHostRegistry();
+    if (!registry || typeof registry.fixedStep !== 'function') {
+      return;
+    }
+    const dt = Number.isFinite(dtOverride) && dtOverride > 0 ? dtOverride : SERVER_FIXED_STEP_DT;
+
+    const localPeerId = runtime.localPeerId;
+    if (localPeerId) {
+      ensureHostServerPlayer(localPeerId);
+      registry.setInput(localPeerId, readLocalInput());
+    }
+
+    runtime.connections.forEach((connection, peerId) => {
+      if (!peerId) {
+        return;
+      }
+      ensureHostServerPlayer(peerId);
+      const entry = runtime.peerInputs[peerId];
+      if (entry && entry.payload && entry.payload.p) {
+        registry.setInput(peerId, normalizePeerInput(entry.payload.p));
+      }
+    });
+
+    registry.fixedStep(dt);
+
+    const snapshot = registry.getPlayers();
+    runtime.remotePlayers = snapshot
+      .filter((player) => player && player.id !== runtime.localPeerId)
+      .map((player) => ({
+        id: player.id,
+        name: getPlayerName(player.id),
+        x: player.x,
+        y: player.y,
+        facing: player.facing,
+      }));
+
+    if (runtime.scene && typeof runtime.scene.renderRemotePlayers === 'function') {
+      runtime.scene.renderRemotePlayers(runtime.remotePlayers);
+    }
+  }
+
   function getStickFightNet() {
     const net = global.StickFightNet;
     if (!net || typeof net.ensureFirestore !== 'function') {
@@ -97,11 +270,19 @@
     }
     const resolvedName = typeof name === 'string' && name.trim() ? name.trim() : 'Player';
     runtime.playerDirectory[safeId] = { name: resolvedName };
+    if (runtime.role === 'host') {
+      updateRegistryPlayerName(safeId, resolvedName);
+    }
   }
 
   function removePlayerFromDirectory(peerId) {
     if (typeof peerId !== 'string') {
       return;
+    }
+    if (runtime.role === 'host' && runtime.registry && typeof runtime.registry.removePlayer === 'function') {
+      if (peerId !== runtime.localPeerId) {
+        runtime.registry.removePlayer(peerId);
+      }
     }
     delete runtime.playerDirectory[peerId];
   }
@@ -270,11 +451,14 @@
             return;
           }
           updatePlayerDirectory(peerId, name);
-          if (runtime.role === 'host' && peerId !== runtime.localPeerId) {
-            ensureHostConnection(peerId);
-          }
           if (!runtime.slotAssignments.p1 && data.isHost) {
             runtime.slotAssignments.p1 = peerId;
+          }
+          if (runtime.role === 'host') {
+            ensureHostServerPlayer(peerId);
+            if (peerId !== runtime.localPeerId) {
+              ensureHostConnection(peerId);
+            }
           }
         });
       },
@@ -356,6 +540,12 @@
     }
     clearConnectionRateTimers(record);
     runtime.connections.delete(peerId);
+    if (runtime.registry && typeof runtime.registry.removePlayer === 'function' && peerId !== runtime.localPeerId) {
+      runtime.registry.removePlayer(peerId);
+    }
+    if (runtime.peerInputs && Object.prototype.hasOwnProperty.call(runtime.peerInputs, peerId)) {
+      delete runtime.peerInputs[peerId];
+    }
     updateDiagnosticsOverlay();
   }
 
@@ -432,6 +622,7 @@
     if (!runtime.slotAssignments.p2) {
       runtime.slotAssignments.p2 = peerId;
     }
+    ensureHostServerPlayer(peerId);
 
     const sessionDoc = runtime.roomRef.collection('webrtc').doc(peerId);
     connection.sessionDoc = sessionDoc;
@@ -530,11 +721,21 @@
         peerId,
         JSON.stringify({ mx: moveX, cr: crouch, pu: punch, ki: kick, ju: jumpDir })
       );
+      if (runtime.registry && typeof runtime.registry.setInput === 'function') {
+        runtime.registry.setInput(peerId, normalizePeerInput(payload.p));
+      }
       updateDiagnosticsOverlay();
     };
   }
 
   function startHostRuntime() {
+    ensureHostRegistry();
+    ensureHostServerPlayer(runtime.localPeerId);
+    if (!runtime.serverStepTimer) {
+      const interval = Math.max(1, Math.round(SERVER_FIXED_STEP_MS));
+      runtime.serverStepTimer = setInterval(() => stepHostServer(), interval);
+    }
+    stepHostServer();
     if (runtime.stateBroadcastTimer) {
       return;
     }
@@ -862,6 +1063,10 @@
       return;
     }
     runtime.scene = scene;
+    if (runtime.role === 'host') {
+      ensureHostRegistry();
+      stepHostServer();
+    }
     if (runtime.lastDiag && typeof scene.updateNetDiagOverlay === 'function') {
       scene.updateNetDiagOverlay(runtime.lastDiag);
     }
@@ -905,6 +1110,11 @@
       clearInterval(runtime.stateBroadcastTimer);
       runtime.stateBroadcastTimer = null;
     }
+    if (runtime.serverStepTimer) {
+      clearInterval(runtime.serverStepTimer);
+      runtime.serverStepTimer = null;
+    }
+    runtime.registry = null;
     runtime.remotePlayers = [];
     runtime.peerInputs = {};
     updateDiagnosticsOverlay();

--- a/tests/net-server.test.js
+++ b/tests/net-server.test.js
@@ -1,0 +1,101 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const HostServer = require('../public/net-server.js');
+
+const { createRegistry, SPEED, ACCEL, FRICTION, JUMP_V, GRAVITY } = HostServer;
+
+const DT = 1 / 60;
+
+test('server applies horizontal acceleration toward target speed', () => {
+  const registry = createRegistry();
+  registry.ensurePlayer('host', { slot: 'p1' });
+  registry.setInput('host', { mx: 1, ju: 0 });
+  registry.fixedStep(DT);
+  const player = registry.getPlayer('host');
+  const expectedVx = Math.min(ACCEL * DT, SPEED);
+  assert.ok(Math.abs(player.vx - expectedVx) < 1e-6);
+  assert.ok(player.x > 0);
+});
+
+test('server applies ground friction when no input', () => {
+  const registry = createRegistry();
+  const internal = registry.ensurePlayer('p1', { slot: 'p1' });
+  internal.vx = SPEED * 0.5;
+  registry.setInput('p1', { mx: 0, ju: 0 });
+  registry.fixedStep(DT);
+  const updated = registry.getPlayer('p1');
+  const expected = Math.max(SPEED * 0.5 - ACCEL * DT, 0);
+  assert.ok(Math.abs(updated.vx - expected) < 1e-6);
+});
+
+test('server applies jump impulse and gravity', () => {
+  const registry = createRegistry();
+  const internal = registry.ensurePlayer('jumper', { slot: 'p1' });
+  const startY = internal.y;
+  registry.setInput('jumper', { mx: 0, ju: 1 });
+  registry.fixedStep(DT);
+  const player = registry.getPlayer('jumper');
+  const expectedVy = -JUMP_V + GRAVITY * DT;
+  assert.ok(Math.abs(player.vy - expectedVy) < 1e-6);
+  assert.equal(player.onGround, false);
+  assert.ok(player.y < startY);
+  assert.ok(player.vx > 0);
+});
+
+test('server applies gravity while airborne', () => {
+  const registry = createRegistry();
+  const internal = registry.ensurePlayer('air', { slot: 'p1' });
+  internal.onGround = false;
+  internal.vy = 0;
+  internal.y -= 80;
+  registry.setInput('air', { mx: 0, ju: 0 });
+  registry.fixedStep(DT);
+  const player = registry.getPlayer('air');
+  assert.ok(Math.abs(player.vy - GRAVITY * DT) < 1e-6);
+  assert.equal(player.onGround, false);
+});
+
+test('server clamps to floor and resets velocity', () => {
+  const registry = createRegistry();
+  const internal = registry.ensurePlayer('floor', { slot: 'p1' });
+  const floorY = registry.playRect.y + registry.playRect.height - internal.halfHeight;
+  internal.y = floorY;
+  internal.vy = 200;
+  internal.onGround = false;
+  registry.setInput('floor', { mx: 0, ju: 0 });
+  registry.fixedStep(DT);
+  const player = registry.getPlayer('floor');
+  assert.equal(player.y, floorY);
+  assert.equal(player.vy, 0);
+  assert.equal(player.onGround, true);
+});
+
+test('server clamps to horizontal bounds and zeroes velocity', () => {
+  const registry = createRegistry();
+  const internal = registry.ensurePlayer('edge', { slot: 'p1' });
+  const minX = registry.playRect.x + internal.halfWidth;
+  internal.x = minX - 10;
+  internal.vx = -SPEED;
+  registry.setInput('edge', { mx: 0, ju: 0 });
+  registry.fixedStep(DT);
+  const player = registry.getPlayer('edge');
+  assert.ok(player.x >= minX - 1e-6);
+  assert.ok(player.vx >= 0);
+});
+
+test('server updates facing toward nearest opponent', () => {
+  const registry = createRegistry();
+  const p1 = registry.ensurePlayer('p1', { slot: 'p1' });
+  const p2 = registry.ensurePlayer('p2', { slot: 'p2' });
+  p2.x = p1.x + 120;
+  registry.setInput('p1', { mx: 0, ju: 0 });
+  registry.setInput('p2', { mx: 0, ju: 0 });
+  registry.fixedStep(DT);
+  let player = registry.getPlayer('p1');
+  assert.equal(player.facing, 1);
+  p2.x = p1.x - 120;
+  registry.fixedStep(DT);
+  player = registry.getPlayer('p1');
+  assert.equal(player.facing, -1);
+});


### PR DESCRIPTION
## Summary
- add a standalone host server module that tracks player state with acceleration, jumping, gravity, and playfield clamping
- wire StickFightNetplay host runtime to maintain a registry, feed inputs, and periodically step the server for remote diagnostics
- load the new module on the client and add unit tests that cover movement, gravity, facing, and boundary handling

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68ca6fd5240c832eb4c5799cdbb65783