### PR TITLE
Normalize joystick moveX using dominant axis

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -4082,7 +4082,9 @@ if (typeof this.positionNetDiagOverlay === 'function') {
           return;
         }
 
-        snapshot.moveX = Phaser.Math.Clamp(vector.x, -1, 1);
+        const maxComponent = Math.max(Math.abs(vector.x), Math.abs(vector.y));
+        const normalizedX = maxComponent > 0 ? vector.x / maxComponent : 0;
+        snapshot.moveX = Phaser.Math.Clamp(normalizedX * vector.magnitude, -1, 1);
 
         const crouchActive = vector.y >= JOYSTICK_CROUCH_THRESHOLD;
         snapshot.crouch = crouchActive;


### PR DESCRIPTION
## Summary
- adjust joystick snapshot horizontal calculation to normalize diagonals by dominant axis

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca817dc284832e9e23367697b92b06