### PR TITLE
Implement single-device claims and mobile controls

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,14 @@
+// One-player-per-device per uid per room
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /rooms/{roomId}/players/{uid} {
+      allow read: if true;
+      allow create, update: if request.auth != null
+        && request.auth.uid == uid
+        && (!exists(/databases/$(db)/documents/rooms/$(roomId)/players/$(uid))
+            || request.resource.data.deviceId == resource.data.deviceId);
+      allow delete: if request.auth != null && request.auth.uid == uid;
+    }
+  }
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,0 +1,72 @@
+type BaseAction = {
+  type: 'MOVE' | 'PUNCH' | 'KICK';
+  actorUid: string;
+  createdByUid?: string;
+  createdAt?: number;
+};
+
+type MoveAction = BaseAction & {
+  type: 'MOVE';
+  ax: number;
+  ay: number;
+  mag?: number;
+};
+
+type PunchAction = BaseAction & {
+  type: 'PUNCH';
+};
+
+type KickAction = BaseAction & {
+  type: 'KICK';
+};
+
+type PlayerAction = MoveAction | PunchAction | KickAction;
+
+const actionQueues: Map<string, PlayerAction[]> = new Map();
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return value > 0 ? max : min;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+export function enqueueAction(roomId: string, action: PlayerAction): void {
+  if (!roomId) {
+    throw new Error('roomId is required');
+  }
+  if (!action || typeof action !== 'object') {
+    throw new Error('action is required');
+  }
+  if (!action.actorUid) {
+    throw new Error('actorUid is required');
+  }
+  const entry: PlayerAction = {
+    ...action,
+    ax: 'ax' in action ? clamp(action.ax, -1, 1) : undefined,
+    ay: 'ay' in action ? clamp(action.ay, -1, 1) : undefined,
+    mag: 'mag' in action ? clamp(action.mag ?? 0, 0, 1) : undefined,
+    createdAt: action.createdAt ?? Date.now(),
+  } as PlayerAction;
+
+  const queue = actionQueues.get(roomId);
+  if (queue) {
+    queue.push(entry);
+  } else {
+    actionQueues.set(roomId, [entry]);
+  }
+}
+
+export function consumeQueuedActions(roomId: string): PlayerAction[] {
+  if (!roomId) {
+    return [];
+  }
+  const queue = actionQueues.get(roomId);
+  if (!queue || queue.length === 0) {
+    return [];
+  }
+  actionQueues.set(roomId, []);
+  return queue.slice();
+}
+
+export type { PlayerAction, MoveAction, PunchAction, KickAction };

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -1,0 +1,84 @@
+const DEVICE_ID_KEY = 'deviceId';
+const LOG_PREFIX = '[AUTH]';
+
+function randomId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const array = typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function'
+    ? crypto.getRandomValues(new Uint8Array(16))
+    : Array.from({ length: 16 }, () => Math.floor(Math.random() * 256));
+  return Array.from(array, (value) => value.toString(16).padStart(2, '0')).join('');
+}
+
+export function getDeviceId(): string {
+  try {
+    const storage = typeof window !== 'undefined' ? window.localStorage : undefined;
+    if (!storage) {
+      return randomId();
+    }
+    const existing = storage.getItem(DEVICE_ID_KEY);
+    if (typeof existing === 'string' && existing.length > 0) {
+      return existing;
+    }
+    const next = randomId();
+    storage.setItem(DEVICE_ID_KEY, next);
+    return next;
+  } catch (error) {
+    return randomId();
+  }
+}
+
+type FirebaseAuth = {
+  currentUser: { uid: string } | null;
+  signInAnonymously?: () => Promise<{ user: { uid: string } | null }>;
+};
+
+type FirebaseNamespace = {
+  auth?: () => FirebaseAuth;
+};
+
+let signingIn: Promise<{ auth: FirebaseAuth; user: { uid: string } }> | null = null;
+
+export async function ensureSignedInUser(): Promise<{ auth: FirebaseAuth; user: { uid: string } }>
+{
+  const firebaseNamespace: FirebaseNamespace | undefined =
+    typeof window !== 'undefined' ? (window as any).firebase : undefined;
+  if (!firebaseNamespace || typeof firebaseNamespace.auth !== 'function') {
+    throw new Error('Firebase Auth SDK is not available.');
+  }
+  const auth = firebaseNamespace.auth();
+  if (!auth) {
+    throw new Error('Failed to obtain Firebase Auth instance.');
+  }
+  if (auth.currentUser) {
+    const deviceId = getDeviceId();
+    if (typeof console !== 'undefined' && console && typeof console.log === 'function') {
+      console.log(`${LOG_PREFIX} uid=${auth.currentUser.uid} deviceId=${deviceId}`);
+    }
+    return { auth, user: auth.currentUser };
+  }
+  if (!signingIn) {
+    if (typeof auth.signInAnonymously !== 'function') {
+      throw new Error('Firebase Auth does not support anonymous sign-in.');
+    }
+    signingIn = auth
+      .signInAnonymously()
+      .then((cred) => {
+        const user = (cred && cred.user) || auth.currentUser;
+        if (!user) {
+          throw new Error('Anonymous sign-in returned no user.');
+        }
+        return { auth, user };
+      })
+      .finally(() => {
+        signingIn = null;
+      });
+  }
+  const result = await signingIn;
+  const deviceId = getDeviceId();
+  if (typeof console !== 'undefined' && console && typeof console.log === 'function') {
+    console.log(`${LOG_PREFIX} uid=${result.user.uid} deviceId=${deviceId}`);
+  }
+  return result;
+}

--- a/src/net/consume.ts
+++ b/src/net/consume.ts
@@ -1,0 +1,53 @@
+import { consumeQueuedActions, PlayerAction } from '../lib/actions';
+
+type Listener = (actions: PlayerAction[]) => void;
+
+const listeners: Set<Listener> = new Set();
+let pollingRoomId: string | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+function notify(actions: PlayerAction[]) {
+  if (actions.length === 0) {
+    return;
+  }
+  listeners.forEach((listener) => {
+    try {
+      listener(actions);
+    } catch (error) {
+      if (typeof console !== 'undefined' && console && typeof console.error === 'function') {
+        console.error('[NET][CONSUME] listener failed', error);
+      }
+    }
+  });
+}
+
+function tick() {
+  if (!pollingRoomId) {
+    return;
+  }
+  const actions = consumeQueuedActions(pollingRoomId);
+  notify(actions);
+}
+
+export function startConsuming(roomId: string, intervalMs = 50): void {
+  pollingRoomId = roomId;
+  if (pollTimer) {
+    clearInterval(pollTimer);
+  }
+  pollTimer = setInterval(tick, intervalMs);
+}
+
+export function stopConsuming(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  pollingRoomId = null;
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/net/playerClaim.ts
+++ b/src/net/playerClaim.ts
@@ -1,0 +1,178 @@
+import { getDeviceId, ensureSignedInUser } from '../lib/identity';
+
+type CollectionReference = {
+  doc: (path: string) => any;
+};
+
+type Firestore = {
+  doc?: (path: string) => any;
+  collection?: (path: string) => CollectionReference;
+  runTransaction: <T>(updateFn: (transaction: any) => Promise<T>) => Promise<T>;
+};
+
+type FirestoreNamespace = (() => Firestore) & {
+  FieldValue?: { serverTimestamp?: () => any };
+};
+
+type FirebaseNamespace = {
+  firestore?: FirestoreNamespace;
+};
+
+type PlayerDoc = {
+  uid: string;
+  deviceId: string;
+  nick: string;
+  joinedAt: unknown;
+  lastSeenAt: unknown;
+  hp: number;
+};
+
+type HeartbeatHandle = {
+  stop: () => void;
+};
+
+type ClaimResult = {
+  uid: string;
+  deviceId: string;
+  heartbeat: HeartbeatHandle;
+};
+
+const HEARTBEAT_MS = 15000;
+const ERR_DEVICE_MISMATCH = 'ERR_DEVICE_MISMATCH';
+
+function getFirebase(): FirebaseNamespace | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  const firebase = (window as any).firebase;
+  if (firebase && typeof firebase.firestore === 'function') {
+    return firebase;
+  }
+  return undefined;
+}
+
+function getFirestore(): Firestore {
+  const firebase = getFirebase();
+  if (!firebase || typeof firebase.firestore !== 'function') {
+    throw new Error('Firestore SDK is not available.');
+  }
+  return firebase.firestore();
+}
+
+function getPlayerRef(firestore: Firestore, roomId: string, uid: string) {
+  if (typeof firestore.doc === 'function') {
+    return firestore.doc(`rooms/${roomId}/players/${uid}`);
+  }
+  if (typeof firestore.collection === 'function') {
+    const rooms = firestore.collection('rooms');
+    const roomRef: any = rooms.doc(roomId);
+    const players = roomRef && typeof roomRef.collection === 'function' ? roomRef.collection('players') : null;
+    if (players && typeof players.doc === 'function') {
+      return players.doc(uid);
+    }
+  }
+  throw new Error('Firestore API does not support document access.');
+}
+
+function serverTimestamp() {
+  const firebase = getFirebase();
+  if (firebase && firebase.firestore && firebase.firestore.FieldValue &&
+    typeof firebase.firestore.FieldValue.serverTimestamp === 'function') {
+    return firebase.firestore.FieldValue.serverTimestamp();
+  }
+  return new Date();
+}
+
+function createHeartbeat(ref: any): HeartbeatHandle {
+  let stopped = false;
+
+  const send = () => {
+    if (stopped) {
+      return Promise.resolve();
+    }
+    try {
+      return ref.update({ lastSeenAt: serverTimestamp() }).catch(() => undefined);
+    } catch (error) {
+      return Promise.resolve();
+    }
+  };
+
+  const intervalId = setInterval(() => {
+    send();
+  }, HEARTBEAT_MS);
+
+  const cleanupListeners: Array<() => void> = [];
+
+  const stop = () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    clearInterval(intervalId);
+    send();
+    cleanupListeners.forEach((fn) => {
+      try {
+        fn();
+      } catch (error) {
+        // ignore cleanup failure
+      }
+    });
+  };
+
+  if (typeof window !== 'undefined') {
+    const visibilityHandler = () => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+        stop();
+      }
+    };
+    window.addEventListener('visibilitychange', visibilityHandler, { passive: true });
+    cleanupListeners.push(() => window.removeEventListener('visibilitychange', visibilityHandler));
+
+    const exitHandler = () => stop();
+    window.addEventListener('pagehide', exitHandler);
+    window.addEventListener('beforeunload', exitHandler);
+    cleanupListeners.push(() => {
+      window.removeEventListener('pagehide', exitHandler);
+      window.removeEventListener('beforeunload', exitHandler);
+    });
+  }
+
+  return { stop };
+}
+
+export async function claimPlayer(roomId: string, nick: string): Promise<ClaimResult> {
+  if (!roomId) {
+    throw new Error('roomId is required.');
+  }
+  const { user } = await ensureSignedInUser();
+  const deviceId = getDeviceId();
+  const firestore = getFirestore();
+  const ref = getPlayerRef(firestore, roomId, user.uid);
+
+  await firestore.runTransaction(async (transaction: any) => {
+    const snapshot = await transaction.get(ref);
+    const existing = snapshot && typeof snapshot.data === 'function' ? snapshot.data() : null;
+    if (existing && existing.deviceId && existing.deviceId !== deviceId) {
+      const error = new Error(ERR_DEVICE_MISMATCH);
+      (error as any).code = ERR_DEVICE_MISMATCH;
+      (error as any).uid = user.uid;
+      throw error;
+    }
+    const now = serverTimestamp();
+    const payload: PlayerDoc = {
+      uid: user.uid,
+      deviceId,
+      nick,
+      joinedAt: existing && existing.joinedAt ? existing.joinedAt : now,
+      lastSeenAt: now,
+      hp: typeof (existing && existing.hp) === 'number' ? existing.hp : 100,
+    };
+    transaction.set(ref, payload, { merge: true });
+  });
+
+  const heartbeat = createHeartbeat(ref);
+  return { uid: user.uid, deviceId, heartbeat };
+}
+
+export { ERR_DEVICE_MISMATCH };
+export type { HeartbeatHandle, ClaimResult };

--- a/src/net/send.ts
+++ b/src/net/send.ts
@@ -1,0 +1,72 @@
+import { enqueueAction } from '../lib/actions';
+import { ensureSignedInUser } from '../lib/identity';
+
+type MovePayload = {
+  ax: number;
+  ay: number;
+  mag?: number;
+};
+
+type LocalContext = {
+  roomId: string;
+  uid: string;
+};
+
+let localContext: LocalContext | null = null;
+
+export function setLocalContext(roomId: string, uid: string): void {
+  localContext = { roomId, uid };
+}
+
+function getContext(): LocalContext {
+  if (localContext) {
+    return localContext;
+  }
+  throw new Error('Local player context has not been established.');
+}
+
+export async function sendMove(payload: MovePayload): Promise<void> {
+  const context = getContext();
+  const { user } = await ensureSignedInUser();
+  if (user.uid !== context.uid) {
+    return;
+  }
+  enqueueAction(context.roomId, {
+    type: 'MOVE',
+    ax: payload.ax,
+    ay: payload.ay,
+    mag: payload.mag,
+    actorUid: context.uid,
+    createdByUid: context.uid,
+  });
+}
+
+export async function sendPunch(): Promise<void> {
+  const context = getContext();
+  const { user } = await ensureSignedInUser();
+  if (user.uid !== context.uid) {
+    return;
+  }
+  enqueueAction(context.roomId, {
+    type: 'PUNCH',
+    actorUid: context.uid,
+    createdByUid: context.uid,
+  });
+}
+
+export async function sendKick(): Promise<void> {
+  const context = getContext();
+  const { user } = await ensureSignedInUser();
+  if (user.uid !== context.uid) {
+    return;
+  }
+  enqueueAction(context.roomId, {
+    type: 'KICK',
+    actorUid: context.uid,
+    createdByUid: context.uid,
+  });
+}
+
+export function clearLocalContext(): void {
+  localContext = null;
+}

--- a/src/ui/HUD.tsx
+++ b/src/ui/HUD.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import './hud.css';
+
+type PlayerInfo = {
+  uid: string;
+  nick: string;
+  hp: number;
+};
+
+type HUDProps = {
+  players: PlayerInfo[];
+};
+
+const MAX_HP = 100;
+
+function normalizeHp(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(value, MAX_HP));
+}
+
+const HUD: React.FC<HUDProps> = ({ players }) => {
+  if (!players || players.length === 0) {
+    return null;
+  }
+  return (
+    <div className="hud-root">
+      {players.map((player) => {
+        const hp = normalizeHp(player.hp);
+        const percent = (hp / MAX_HP) * 100;
+        return (
+          <div className="hud-player" key={player.uid}>
+            <span className="hud-nick">{player.nick}</span>
+            <div className="hud-bar">
+              <div className="hud-bar-fill" style={{ width: `${percent}%` }} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default HUD;

--- a/src/ui/RoomView.tsx
+++ b/src/ui/RoomView.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import MobileControls from './controls/MobileControls';
+import { claimPlayer, ERR_DEVICE_MISMATCH, HeartbeatHandle } from '../net/playerClaim';
+import { setLocalContext, clearLocalContext } from '../net/send';
+import { startConsuming, stopConsuming } from '../net/consume';
+import { getDeviceId } from '../lib/identity';
+
+type RoomViewProps = {
+  roomId: string;
+  nick: string;
+  children?: React.ReactNode;
+};
+
+type ClaimState = {
+  uid: string;
+  deviceId: string;
+  heartbeat: HeartbeatHandle;
+};
+
+type ViewState = 'loading' | 'ready' | 'blocked' | 'error';
+
+export default function RoomView({ roomId, nick, children }: RoomViewProps) {
+  const [state, setState] = useState<ViewState>('loading');
+  const [error, setError] = useState<Error | null>(null);
+  const [claim, setClaim] = useState<ClaimState | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let heartbeat: HeartbeatHandle | null = null;
+
+    setState('loading');
+    setError(null);
+    setClaim(null);
+
+    claimPlayer(roomId, nick)
+      .then((result) => {
+        if (cancelled) {
+          result.heartbeat.stop();
+          return;
+        }
+        heartbeat = result.heartbeat;
+        setClaim(result);
+        setLocalContext(roomId, result.uid);
+        startConsuming(roomId);
+        setState('ready');
+      })
+      .catch((err: Error & { code?: string; uid?: string }) => {
+        if (cancelled) {
+          return;
+        }
+        if (err && (err.message === ERR_DEVICE_MISMATCH || err.code === ERR_DEVICE_MISMATCH)) {
+          const deviceId = getDeviceId();
+          const uid = err.uid || (err as any).uid || 'unknown';
+          if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+            console.warn(`[INPUT][BLOCK] device-mismatch uid=${uid} deviceId=${deviceId}`);
+          }
+          setState('blocked');
+        } else {
+          setState('error');
+          setError(err);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      stopConsuming();
+      clearLocalContext();
+      if (heartbeat) {
+        heartbeat.stop();
+      }
+    };
+  }, [roomId, nick]);
+
+  if (state === 'loading') {
+    return (
+      <div className="room-view loading">
+        <p>Joining room…</p>
+      </div>
+    );
+  }
+
+  if (state === 'blocked') {
+    return (
+      <div className="room-view blocked">
+        <div className="modal">
+          <h2>Device Claimed</h2>
+          <p>This player is claimed on another device. Leave room or sign in on that device.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <div className="room-view error">
+        <p>Failed to join room.</p>
+        {error ? <pre>{String(error.message || error)}</pre> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="room-view ready">
+      {children}
+      {claim ? <MobileControls /> : null}
+    </div>
+  );
+}

--- a/src/ui/controls/MobileControls.tsx
+++ b/src/ui/controls/MobileControls.tsx
@@ -1,0 +1,359 @@
+import React, { useEffect, useRef } from 'react';
+import { getDeviceId, ensureSignedInUser } from '../../lib/identity';
+import { sendMove, sendPunch, sendKick } from '../../net/send';
+
+import './controls.css';
+
+const DEADZONE = 0.12;
+const REPEAT_MS = 110; // ~9Hz
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+function normalizeAxis(dx: number, dy: number, radius: number) {
+  if (radius <= 0) {
+    return { ax: 0, ay: 0, mag: 0 };
+  }
+  const rawAx = clamp(dx / radius, -1, 1);
+  const rawAy = clamp(dy / radius, -1, 1);
+  const magnitude = Math.min(Math.hypot(rawAx, rawAy), 1);
+  if (magnitude < DEADZONE) {
+    return { ax: 0, ay: 0, mag: 0 };
+  }
+  const scaledMag = (magnitude - DEADZONE) / (1 - DEADZONE);
+  const scale = magnitude === 0 ? 0 : scaledMag / magnitude;
+  return {
+    ax: clamp(rawAx * scale, -1, 1),
+    ay: clamp(rawAy * scale, -1, 1),
+    mag: clamp(scaledMag, 0, 1),
+  };
+}
+
+function vibrate(ms = 12) {
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+      navigator.vibrate(ms);
+    }
+  } catch (error) {
+    // ignore vibration errors
+  }
+}
+
+function isDesktop(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  const ua = navigator.userAgent || '';
+  const lower = ua.toLowerCase();
+  if (/android|iphone|ipad|ipod/.test(lower)) {
+    return false;
+  }
+  return /macintosh|mac os x|windows|linux/.test(lower);
+}
+
+type PointerState = {
+  pointerId: number | null;
+};
+
+type RepeatHandle = {
+  start: () => void;
+  stop: () => void;
+};
+
+function createRepeater(callback: () => void): RepeatHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  const start = () => {
+    if (timer) {
+      return;
+    }
+    callback();
+    timer = setInterval(callback, REPEAT_MS);
+  };
+  const stop = () => {
+    if (!timer) {
+      return;
+    }
+    clearInterval(timer);
+    timer = null;
+  };
+  return { start, stop };
+}
+
+const MobileControls: React.FC = () => {
+  const knobRef = useRef<HTMLDivElement>(null);
+  const joystickRef = useRef<HTMLDivElement>(null);
+  const pointerStateRef = useRef<PointerState>({ pointerId: null });
+  const frameRequest = useRef<number | null>(null);
+  const pendingAxis = useRef<{ ax: number; ay: number; mag: number }>({ ax: 0, ay: 0, mag: 0 });
+  const punchRef = useRef<HTMLButtonElement>(null);
+  const kickRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    ensureSignedInUser()
+      .then(({ user }) => {
+        if (cancelled) {
+          return;
+        }
+        const deviceId = getDeviceId();
+        const width = typeof window !== 'undefined' ? window.innerWidth : 0;
+        const height = typeof window !== 'undefined' ? window.innerHeight : 0;
+        if (typeof console !== 'undefined' && console && typeof console.log === 'function') {
+          console.log(`[INPUT] controls-mounted uid=${user.uid} deviceId=${deviceId} vw=${width}x${height}`);
+        }
+      })
+      .catch((error) => {
+        if (typeof console !== 'undefined' && console && typeof console.error === 'function') {
+          console.error('[INPUT] controls-mounted failed', error);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const joystick = joystickRef.current;
+    const knob = knobRef.current;
+    if (!joystick || !knob) {
+      return;
+    }
+
+    const state = pointerStateRef.current;
+
+    const renderAxis = () => {
+      frameRequest.current = null;
+      const { ax, ay, mag } = pendingAxis.current;
+      knob.style.transform = `translate(calc(${50 + ax * 40}% - 50%), calc(${50 + ay * 40}% - 50%))`;
+      sendMove({ ax, ay, mag }).catch((error) => {
+        if (typeof console !== 'undefined' && console && typeof console.error === 'function') {
+          console.error('[INPUT] sendMove failed', error);
+        }
+      });
+    };
+
+    const scheduleRender = () => {
+      if (frameRequest.current !== null) {
+        return;
+      }
+      frameRequest.current = requestAnimationFrame(renderAxis);
+    };
+
+    const resetAxis = () => {
+      pendingAxis.current = { ax: 0, ay: 0, mag: 0 };
+      scheduleRender();
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (state.pointerId !== null) {
+        return;
+      }
+      event.preventDefault();
+      joystick.setPointerCapture(event.pointerId);
+      state.pointerId = event.pointerId;
+      const { width } = joystick.getBoundingClientRect();
+      const axis = normalizeAxis(0, 0, width / 2);
+      pendingAxis.current = axis;
+      scheduleRender();
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (state.pointerId !== event.pointerId) {
+        return;
+      }
+      event.preventDefault();
+      const rect = joystick.getBoundingClientRect();
+      const radius = Math.min(rect.width, rect.height) / 2;
+      const dx = event.clientX - (rect.left + rect.width / 2);
+      const dy = event.clientY - (rect.top + rect.height / 2);
+      pendingAxis.current = normalizeAxis(dx, dy, radius);
+      scheduleRender();
+    };
+
+    const onPointerUp = (event: PointerEvent) => {
+      if (state.pointerId !== event.pointerId) {
+        return;
+      }
+      event.preventDefault();
+      joystick.releasePointerCapture(event.pointerId);
+      state.pointerId = null;
+      resetAxis();
+    };
+
+    const onPointerCancel = (event: PointerEvent) => {
+      if (state.pointerId !== event.pointerId) {
+        return;
+      }
+      event.preventDefault();
+      joystick.releasePointerCapture(event.pointerId);
+      state.pointerId = null;
+      resetAxis();
+    };
+
+    joystick.addEventListener('pointerdown', onPointerDown);
+    joystick.addEventListener('pointermove', onPointerMove, { passive: false });
+    joystick.addEventListener('pointerup', onPointerUp);
+    joystick.addEventListener('pointercancel', onPointerCancel);
+
+    const pause = () => {
+      if (state.pointerId !== null) {
+        state.pointerId = null;
+      }
+      resetAxis();
+    };
+
+    window.addEventListener('blur', pause);
+    window.addEventListener('visibilitychange', pause);
+
+    return () => {
+      joystick.removeEventListener('pointerdown', onPointerDown);
+      joystick.removeEventListener('pointermove', onPointerMove);
+      joystick.removeEventListener('pointerup', onPointerUp);
+      joystick.removeEventListener('pointercancel', onPointerCancel);
+      window.removeEventListener('blur', pause);
+      window.removeEventListener('visibilitychange', pause);
+      if (frameRequest.current !== null) {
+        cancelAnimationFrame(frameRequest.current);
+        frameRequest.current = null;
+      }
+      resetAxis();
+    };
+  }, []);
+
+  useEffect(() => {
+    const punchRepeater = createRepeater(() => {
+      vibrate(12);
+      sendPunch().catch((error) => {
+        if (typeof console !== 'undefined' && console && typeof console.error === 'function') {
+          console.error('[INPUT] sendPunch failed', error);
+        }
+      });
+    });
+    const kickRepeater = createRepeater(() => {
+      vibrate(12);
+      sendKick().catch((error) => {
+        if (typeof console !== 'undefined' && console && typeof console.error === 'function') {
+          console.error('[INPUT] sendKick failed', error);
+        }
+      });
+    });
+
+    const punchButton = punchRef.current;
+    const kickButton = kickRef.current;
+    if (!punchButton || !kickButton) {
+      return;
+    }
+
+    const attachButton = (element: HTMLElement, repeater: RepeatHandle) => {
+      const onPointerDown = (event: PointerEvent) => {
+        event.preventDefault();
+        element.setPointerCapture(event.pointerId);
+        repeater.start();
+      };
+      const onPointerUp = (event: PointerEvent) => {
+        element.releasePointerCapture(event.pointerId);
+        repeater.stop();
+      };
+      const onPointerCancel = (event: PointerEvent) => {
+        element.releasePointerCapture(event.pointerId);
+        repeater.stop();
+      };
+      element.addEventListener('pointerdown', onPointerDown);
+      element.addEventListener('pointerup', onPointerUp);
+      element.addEventListener('pointercancel', onPointerCancel);
+      element.addEventListener('pointerleave', onPointerCancel);
+      return () => {
+        element.removeEventListener('pointerdown', onPointerDown);
+        element.removeEventListener('pointerup', onPointerUp);
+        element.removeEventListener('pointercancel', onPointerCancel);
+        element.removeEventListener('pointerleave', onPointerCancel);
+        repeater.stop();
+      };
+    };
+
+    const cleanupPunch = attachButton(punchButton, punchRepeater);
+    const cleanupKick = attachButton(kickButton, kickRepeater);
+
+    return () => {
+      cleanupPunch();
+      cleanupKick();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isDesktop()) {
+      return;
+    }
+
+    const keyState: Record<string, boolean> = {};
+
+    const applyKeyboardAxis = () => {
+      const ax = (keyState['ArrowRight'] || keyState['KeyD'] ? 1 : 0) - (keyState['ArrowLeft'] || keyState['KeyA'] ? 1 : 0);
+      const ay = (keyState['ArrowDown'] || keyState['KeyS'] ? 1 : 0) - (keyState['ArrowUp'] || keyState['KeyW'] ? 1 : 0);
+      const normalized = normalizeAxis(ax, ay, 1);
+      pendingAxis.current = normalized;
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => {
+          sendMove(normalized).catch(() => undefined);
+        });
+      }
+    };
+
+    const punchRepeater = createRepeater(() => {
+      vibrate(12);
+      sendPunch().catch(() => undefined);
+    });
+    const kickRepeater = createRepeater(() => {
+      vibrate(12);
+      sendKick().catch(() => undefined);
+    });
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      keyState[event.code] = true;
+      if (event.code === 'KeyJ') {
+        event.preventDefault();
+        punchRepeater.start();
+      } else if (event.code === 'KeyK') {
+        event.preventDefault();
+        kickRepeater.start();
+      } else if (event.code.startsWith('Arrow') || event.code === 'KeyW' || event.code === 'KeyA' || event.code === 'KeyS' || event.code === 'KeyD') {
+        event.preventDefault();
+        applyKeyboardAxis();
+      }
+    };
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      keyState[event.code] = false;
+      if (event.code === 'KeyJ') {
+        punchRepeater.stop();
+      } else if (event.code === 'KeyK') {
+        kickRepeater.stop();
+      } else if (event.code.startsWith('Arrow') || event.code === 'KeyW' || event.code === 'KeyA' || event.code === 'KeyS' || event.code === 'KeyD') {
+        applyKeyboardAxis();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      punchRepeater.stop();
+      kickRepeater.stop();
+    };
+  }, []);
+
+  return (
+    <div className="controls-root">
+      <div id="joystick" className="joy-wrap" ref={joystickRef}>
+        <div className="joy-knob" ref={knobRef} />
+      </div>
+      <div className="btn-wrap">
+        <button id="btn-punch" className="btn action" type="button" ref={punchRef}>Punch</button>
+        <button id="btn-kick" className="btn alt" type="button" ref={kickRef}>Kick</button>
+      </div>
+    </div>
+  );
+};
+
+export default MobileControls;

--- a/src/ui/controls/controls.css
+++ b/src/ui/controls/controls.css
@@ -1,0 +1,23 @@
+.controls-root{position:fixed;inset:0;pointer-events:none;}
+.joy-wrap{
+  position:fixed; bottom:calc(env(safe-area-inset-bottom) + 12px);
+  left:calc(env(safe-area-inset-left) + 12px);
+  width:min(max(120px,22vw),220px); height:min(max(120px,22vw),220px);
+  border-radius:50%; background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.15);
+  pointer-events:auto; touch-action:none;
+}
+.joy-knob{
+  position:absolute; left:50%; top:50%; width:40%; height:40%;
+  transform:translate(-50%,-50%); border-radius:50%;
+  background:rgba(255,255,255,.25); border:1px solid rgba(255,255,255,.2);
+}
+.btn-wrap{
+  position:fixed; bottom:calc(env(safe-area-inset-bottom) + 12px);
+  right:calc(env(safe-area-inset-right) + 12px); display:flex; gap:2vw;
+  pointer-events:auto;
+}
+.btn{
+  width:min(max(64px,14vw),120px); height:min(max(64px,14vw),120px);
+  border-radius:14px; background:rgba(255,255,255,.12); border:1px solid rgba(255,255,255,.2);
+  color:#fff; font:600 14px/1.2 system-ui; text-transform:uppercase;
+}

--- a/src/ui/hud.css
+++ b/src/ui/hud.css
@@ -1,0 +1,48 @@
+.hud-root {
+  position: fixed;
+  top: calc(env(safe-area-inset-top) + 16px);
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  pointer-events: none;
+  padding: 0 16px;
+  z-index: 20;
+}
+
+.hud-player {
+  min-width: 120px;
+  max-width: 180px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 8px 12px;
+  color: #fff;
+  font: 600 12px/1.4 system-ui;
+  pointer-events: auto;
+}
+
+.hud-nick {
+  display: block;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.hud-bar {
+  position: relative;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.hud-bar-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: linear-gradient(90deg, #ff5252, #ffc107);
+  border-radius: inherit;
+}


### PR DESCRIPTION
## Summary
- add identity utilities to persist a device id and ensure anonymous authentication logging
- guard player claims by device id, start heartbeats, and queue authenticated actions
- introduce mobile controls, HUD, and room view plumbing along with matching Firestore rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf4b1860c832e94edd905ba13040b