### PR TITLE
Fix networking setup syntax

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -2956,8 +2956,6 @@ this.teardownNetworking && this.teardownNetworking();
         netdiag: this._netDiagEnabled,
       });
 
-      });
-
       this.signaling = signaling;
       signaling.start();
       if (session.isHost) {


### PR DESCRIPTION
## Summary
- remove the stray closing parenthesis/brace sequence after the Signaling constructor in `setupNetworking`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cafc596ea0832eb4ff4d86df131c34