### PR TITLE
Attach net helpers to StickFightNet namespace

### DIFF
--- a/public/net.js
+++ b/public/net.js
@@ -132,8 +132,7 @@ function ensureAuthReady() {
   return ensureSignedInUser().then(() => undefined);
 }
 
-// Exports (adjust to your module system)
-export { ensureAuth, ensureSignedInUser, ensureAuthReady };
+  const namespace = global.StickFightNet || {};
 
 
   const getTimestampValue = () => {
@@ -748,13 +747,16 @@ export { ensureAuth, ensureSignedInUser, ensureAuthReady };
 
   initWhenReady();
 
-  global.StickFightNet = {
+  global.StickFightNet = Object.assign(namespace, {
     state: netState,
     ensureFirestore,
+    ensureAuth,
+    ensureSignedInUser,
+    ensureAuthReady,
     createRoom,
     joinRoom,
     buildShareUrl,
     hideOverlay,
     showOverlay,
-  };
+  });
 })(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
## Summary
- expose the authentication helpers on `global.StickFightNet` instead of relying on a module export
- ensure the net overlay helpers continue to register on the shared namespace when the classic script is loaded

## Testing
- Manual smoke test in Chromium (Playwright) to ensure `StickFightNet` loads without syntax errors

------
https://chatgpt.com/codex/tasks/task_e_68cafc6519cc832ebaf38c1e96637ad4