### PR TITLE
Enforce device-bound controls and spectator mode

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -4,10 +4,15 @@ service cloud.firestore {
   match /databases/{db}/documents {
     match /rooms/{roomId}/players/{uid} {
       allow read: if true;
-      allow create, update: if request.auth != null
+      allow create: if request.auth != null
         && request.auth.uid == uid
-        && (!exists(/databases/$(db)/documents/rooms/$(roomId)/players/$(uid))
-            || request.resource.data.deviceId == resource.data.deviceId);
+        && request.resource.data.uid == uid
+        && request.resource.data.deviceId is string
+        && request.resource.data.deviceId != '';
+      allow update: if request.auth != null
+        && request.auth.uid == uid
+        && request.resource.data.uid == uid
+        && request.resource.data.deviceId == resource.data.deviceId;
       allow delete: if request.auth != null && request.auth.uid == uid;
     }
   }


### PR DESCRIPTION
## Summary
- add a shared device identifier helper, enforce device ownership in lobby transactions, and send periodic heartbeats
- align Firestore security rules with the device lock requirements
- gate controls to the owning device, log auth/device information, and show a spectator modal when another device holds the lock

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb101d6af8832ea08f571b00b22c2a