### PR TITLE
Load firebase config before net scripts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -148,6 +148,7 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js" defer></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js" defer></script>
     <script src="joydiag-config.js" defer></script>
+    <script src="firebase-config.js" defer></script>
     <script src="net.js" defer></script>
     <script src="net-server.js" defer></script>
     <script src="netplay.js" defer></script>


### PR DESCRIPTION
## Summary
- ensure firebase-config.js loads before net-related bundles by adding the script ahead of them in index.html

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb225f69f4832e96f7b1650ea05336