### PR TITLE
Improve firebase config validation and logging

### DIFF
--- a/public/firebase-config.js
+++ b/public/firebase-config.js
@@ -16,18 +16,59 @@
   });
 
   const boot = global.__StickFightBoot;
-  const apiKey = config.apiKey || '';
-  const apiKeyLen = typeof apiKey === 'string' ? apiKey.length : 0;
-  const apiKeyHead = apiKeyLen >= 4 ? apiKey.slice(0, 4) : apiKey;
-  const payload =
-    'projectId=' + config.projectId +
-    ' apiKeyLen=' + apiKeyLen +
-    ' apiKeyHead=' + apiKeyHead +
-    ' source=window';
+  const logCfgError = (message) => {
+    const line = '[CFG][ERR] ' + message;
+    if (boot && typeof boot.error === 'function') {
+      boot.error('CFG', message);
+    }
+    if (typeof console !== 'undefined' && console && typeof console.error === 'function') {
+      console.error(line);
+    }
+  };
+
+  const ensureField = (field, minLength) => {
+    const value = config[field];
+    const isString = typeof value === 'string';
+    const actualLength = isString ? value.length : 0;
+    if (!isString || actualLength < minLength) {
+      const reason = !isString || actualLength === 0 ? 'missing' : 'too short';
+      logCfgError(field + ' ' + reason + ' in firebase config');
+      throw new Error('CFG_INVALID_FIELD: ' + field);
+    }
+    return value;
+  };
+
+  const apiKey = ensureField('apiKey', 6);
+  const authDomain = ensureField('authDomain', 1);
+  const projectId = ensureField('projectId', 1);
+  ensureField('appId', 1);
+
+  const apiKeyLen = apiKey.length;
+  const apiKeyHead = apiKey.slice(0, 6);
+  const source =
+    typeof window !== 'undefined' && global === window
+      ? 'window'
+      : typeof globalThis !== 'undefined' && global === globalThis
+      ? 'globalThis'
+      : 'unknown';
+  const logDetails =
+    'source=' +
+    source +
+    ' projectId=' +
+    projectId +
+    ' authDomain=' +
+    authDomain +
+    ' apiKeyLen=' +
+    apiKeyLen +
+    ' apiKeyHead=' +
+    apiKeyHead;
+  const logLine = '[CFG] ' + logDetails;
+
   if (boot && typeof boot.log === 'function') {
-    boot.log('CFG', payload);
-  } else if (typeof console !== 'undefined' && console && typeof console.info === 'function') {
-    console.info('[CFG] ' + payload);
+    boot.log('CFG', logDetails);
+  }
+  if (typeof console !== 'undefined' && console && typeof console.info === 'function') {
+    console.info(logLine);
   }
 
   global.__FIREBASE_CONFIG__ = config;

--- a/public/main.js
+++ b/public/main.js
@@ -1,3 +1,7 @@
+if (!window.__FIREBASE_CONFIG__) {
+  throw new Error('CFG_MISSING: window.__FIREBASE_CONFIG__ not defined');
+}
+
 (function () {
   const Boot = (() => {
     if (typeof window !== 'undefined' && window.__StickFightBoot) {

--- a/public/net.js
+++ b/public/net.js
@@ -77,6 +77,29 @@
     return null;
   };
 
+  const describeFirebaseConfig = () => {
+    const config = getFirebaseConfig();
+    const projectId = config && typeof config.projectId === 'string' ? config.projectId : 'missing';
+    const authDomain = config && typeof config.authDomain === 'string' ? config.authDomain : 'missing';
+    const apiKey = config && typeof config.apiKey === 'string' ? config.apiKey : '';
+    const apiKeyHead = apiKey ? apiKey.slice(0, 6) : 'missing';
+    return { config, projectId, authDomain, apiKeyHead };
+  };
+
+  const logConfigScope = (scope) => {
+    const { projectId, authDomain, apiKeyHead } = describeFirebaseConfig();
+    const message =
+      'scope=' +
+      scope +
+      ' projectId=' +
+      projectId +
+      ' authDomain=' +
+      authDomain +
+      ' apiKeyHead=' +
+      apiKeyHead;
+    bootLog('CFG', message);
+  };
+
   const ensureFirebaseApp = () => {
     if (NETWORK_DISABLED) {
       throw new Error('Networking disabled by query flags.');
@@ -334,6 +357,7 @@ function ensureAuthReady() {
   };
 
   const createRoom = async (options) => {
+    logConfigScope('room-create');
     await ensureAuthReady();
     const { auth, user } = await ensureSignedInUser();
     const currentUser = user || (auth && auth.currentUser);
@@ -364,6 +388,7 @@ function ensureAuthReady() {
   };
 
   const joinRoom = async (roomId, options) => {
+    logConfigScope('room-join');
     await ensureAuthReady();
     const firestore = ensureFirestore();
     const { auth, user } = await ensureSignedInUser();
@@ -467,6 +492,7 @@ function ensureAuthReady() {
   };
 
   const adminCreateRoom = async () => {
+    logConfigScope('admin-create-room');
     const { auth, user } = await ensureSignedInUser();
     const currentUser = user || (auth && auth.currentUser);
     if (!currentUser || !currentUser.uid) {
@@ -592,6 +618,7 @@ function ensureAuthReady() {
   };
 
   const startLobbyRoomsListener = async () => {
+    logConfigScope('lobby-listener');
     if (lobbyRoomsState.listening) {
       return;
     }
@@ -626,6 +653,7 @@ function ensureAuthReady() {
   };
 
   const handleAdminEntry = () => {
+    logConfigScope('admin-handle-entry');
     if (overlayState.isAdmin) {
       renderAdminPanel();
       return;


### PR DESCRIPTION
## Summary
- validate firebase config fields before exposing them and log a consistent digest for troubleshooting
- fail fast when the main bundle loads without the firebase config bootstrap
- emit boot-time config digests across lobby, admin, and room network flows to confirm shared configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2319dd48832eaec013be6b6913c0