### PR TITLE
Refine Firebase config resolution

### DIFF
--- a/public/firebase-config.js
+++ b/public/firebase-config.js
@@ -1,11 +1,15 @@
-(function (global) {
+(function (root, factory) {
+  const api = factory(root);
+
+  if (typeof module === 'object' && module && typeof module.exports !== 'undefined') {
+    module.exports = api;
+  } else {
+    api.bootstrap(root);
+  }
+})(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : this, function (global) {
   'use strict';
 
-  if (!global || typeof global !== 'object') {
-    return;
-  }
-
-  const config = Object.freeze({
+  const INLINE_CONFIG = Object.freeze({
     apiKey: 'AIzaSyCTrS0i1Xz9Ll9cSPYnS3sh2g6Pfm7eNcQ',
     authDomain: 'stick-fight-pigeon.firebaseapp.com',
     projectId: 'stick-fight-pigeon',
@@ -15,64 +19,181 @@
     measurementId: 'G-8X0PQR1XYZ',
   });
 
-  const boot = global.__StickFightBoot;
-  const logCfgError = (message) => {
+  const WINDOW_CONFIG_KEYS = Object.freeze([
+    '__FIREBASE_CONFIG__',
+    'STICKFIGHT_FIREBASE_CONFIG',
+    'STICK_FIGHT_FIREBASE_CONFIG',
+    'STICKFIGHT_FIREBASE_OPTIONS',
+  ]);
+
+  const REQUIRED_KEYS = Object.freeze(['apiKey', 'authDomain', 'projectId', 'appId']);
+  const OPTIONAL_REQUIRED_KEYS = Object.freeze(['storageBucket', 'messagingSenderId']);
+
+  const isObject = (value) => Boolean(value) && typeof value === 'object';
+
+  const logError = (loggers, message) => {
     const line = '[CFG][ERR] ' + message;
+    const boot = loggers && loggers.boot;
     if (boot && typeof boot.error === 'function') {
       boot.error('CFG', message);
     }
-    if (typeof console !== 'undefined' && console && typeof console.error === 'function') {
-      console.error(line);
+    const consoleRef = loggers && loggers.console;
+    if (consoleRef && typeof consoleRef.error === 'function') {
+      consoleRef.error(line);
+    }
+    const errorFn = loggers && typeof loggers.error === 'function' ? loggers.error : undefined;
+    if (errorFn) {
+      errorFn(line);
     }
   };
 
-  const ensureField = (field, minLength) => {
-    const value = config[field];
-    const isString = typeof value === 'string';
-    const actualLength = isString ? value.length : 0;
-    if (!isString || actualLength < minLength) {
-      const reason = !isString || actualLength === 0 ? 'missing' : 'too short';
-      logCfgError(field + ' ' + reason + ' in firebase config');
-      throw new Error('CFG_INVALID_FIELD: ' + field);
+  const logInfo = (loggers, message) => {
+    const line = '[CFG] ' + message;
+    const boot = loggers && loggers.boot;
+    if (boot && typeof boot.log === 'function') {
+      boot.log('CFG', message);
     }
-    return value;
+    const consoleRef = loggers && loggers.console;
+    if (consoleRef && typeof consoleRef.info === 'function') {
+      consoleRef.info(line);
+    }
+    const infoFn = loggers && typeof loggers.info === 'function' ? loggers.info : undefined;
+    if (infoFn) {
+      infoFn(line);
+    }
   };
 
-  const apiKey = ensureField('apiKey', 6);
-  const authDomain = ensureField('authDomain', 1);
-  const projectId = ensureField('projectId', 1);
-  ensureField('appId', 1);
+  const normalizeFirebaseConfig = (rawConfig, source, loggers) => {
+    if (!isObject(rawConfig)) {
+      logError(loggers, 'missing=object source=' + source);
+      throw new Error('CFG_INVALID_CONFIG_' + source);
+    }
 
-  const apiKeyLen = apiKey.length;
-  const apiKeyHead = apiKey.slice(0, 6);
-  const source =
-    typeof window !== 'undefined' && global === window
-      ? 'window'
-      : typeof globalThis !== 'undefined' && global === globalThis
-      ? 'globalThis'
-      : 'unknown';
-  const logDetails =
-    'source=' +
-    source +
-    ' projectId=' +
-    projectId +
-    ' authDomain=' +
-    authDomain +
-    ' apiKeyLen=' +
-    apiKeyLen +
-    ' apiKeyHead=' +
-    apiKeyHead;
-  const logLine = '[CFG] ' + logDetails;
+    const candidate = rawConfig;
+    const missing = [];
 
-  if (boot && typeof boot.log === 'function') {
-    boot.log('CFG', logDetails);
+    for (let i = 0; i < REQUIRED_KEYS.length; i += 1) {
+      const key = REQUIRED_KEYS[i];
+      const value = candidate[key];
+      if (typeof value !== 'string' || value.trim() === '') {
+        missing.push(key);
+      }
+    }
+
+    for (let i = 0; i < OPTIONAL_REQUIRED_KEYS.length; i += 1) {
+      const key = OPTIONAL_REQUIRED_KEYS[i];
+      const value = candidate[key];
+      if (typeof value !== 'string' || value.trim() === '') {
+        missing.push(key);
+      }
+    }
+
+    const apiKeyValue = candidate.apiKey;
+    if (typeof apiKeyValue === 'string' && apiKeyValue.length < 20) {
+      missing.push('apiKey(len<20)');
+    }
+
+    if (missing.length > 0) {
+      logError(loggers, 'missing=' + missing.join('|') + ' source=' + source);
+      throw new Error('CFG_INVALID_CONFIG_FIELDS_' + source);
+    }
+
+    return Object.freeze({
+      apiKey: candidate.apiKey,
+      authDomain: candidate.authDomain,
+      projectId: candidate.projectId,
+      storageBucket: candidate.storageBucket,
+      messagingSenderId: candidate.messagingSenderId,
+      appId: candidate.appId,
+      measurementId: candidate.measurementId,
+    });
+  };
+
+  const tryReadGlobalFirebaseConfig = (scope) => {
+    if (!isObject(scope)) {
+      return null;
+    }
+
+    for (let i = 0; i < WINDOW_CONFIG_KEYS.length; i += 1) {
+      const key = WINDOW_CONFIG_KEYS[i];
+      if (key in scope && scope[key]) {
+        return { value: scope[key], key };
+      }
+    }
+
+    return null;
+  };
+
+  const resolveFirebaseConfig = (scope, inlineConfig, loggers) => {
+    const windowConfig = tryReadGlobalFirebaseConfig(scope);
+    if (windowConfig && windowConfig.value) {
+      try {
+        const normalizedWindow = normalizeFirebaseConfig(windowConfig.value, 'window', loggers);
+        return { config: normalizedWindow, source: 'window', key: windowConfig.key };
+      } catch (error) {
+        if (!inlineConfig) {
+          throw error;
+        }
+      }
+    }
+
+    if (!inlineConfig) {
+      logError(loggers, 'missing=config source=inline');
+      throw new Error('CFG_MISSING_INLINE_CONFIG');
+    }
+
+    const normalizedInline = normalizeFirebaseConfig(inlineConfig, 'inline', loggers);
+    return { config: normalizedInline, source: 'inline' };
+  };
+
+  const bootstrap = (scope) => {
+    if (!isObject(scope)) {
+      return null;
+    }
+
+    const loggers = {
+      boot: scope.__StickFightBoot && typeof scope.__StickFightBoot === 'object' ? scope.__StickFightBoot : undefined,
+      console: typeof console !== 'undefined' && console ? console : undefined,
+    };
+
+    const { config, source } = resolveFirebaseConfig(scope, INLINE_CONFIG, loggers);
+    const apiKeyLen = config.apiKey.length;
+    const apiKeyHead = config.apiKey.slice(0, 6);
+    const logDetails =
+      'source=' +
+      source +
+      ' projectId=' +
+      config.projectId +
+      ' authDomain=' +
+      config.authDomain +
+      ' apiKeyLen=' +
+      apiKeyLen +
+      ' apiKeyHead=' +
+      apiKeyHead;
+
+    logInfo(loggers, logDetails);
+
+    scope.__FIREBASE_CONFIG__ = config;
+    scope.STICKFIGHT_FIREBASE_CONFIG = config;
+    scope.STICK_FIGHT_FIREBASE_CONFIG = config;
+    scope.STICKFIGHT_FIREBASE_OPTIONS = config;
+
+    return config;
+  };
+
+  const api = {
+    bootstrap,
+    normalizeFirebaseConfig,
+    resolveFirebaseConfig,
+    tryReadGlobalFirebaseConfig,
+    WINDOW_CONFIG_KEYS,
+    REQUIRED_KEYS,
+    OPTIONAL_REQUIRED_KEYS,
+  };
+
+  if (isObject(global) && !global.__StickFightFirebaseConfigShared) {
+    global.__StickFightFirebaseConfigShared = api;
   }
-  if (typeof console !== 'undefined' && console && typeof console.info === 'function') {
-    console.info(logLine);
-  }
 
-  global.__FIREBASE_CONFIG__ = config;
-  global.STICKFIGHT_FIREBASE_CONFIG = config;
-  global.STICK_FIGHT_FIREBASE_CONFIG = config;
-  global.STICKFIGHT_FIREBASE_OPTIONS = config;
-})(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : this);
+  return api;
+});

--- a/src/types/public__firebase-config-module.d.ts
+++ b/src/types/public__firebase-config-module.d.ts
@@ -1,0 +1,27 @@
+declare module '../../public/firebase-config.js' {
+  import type {
+    FirebaseOptions,
+    FirebaseConfigLoggers,
+    FirebaseConfigResolveResult,
+  } from './public__firebase-config';
+
+  export const WINDOW_CONFIG_KEYS: readonly string[];
+  export const REQUIRED_KEYS: readonly (keyof FirebaseOptions)[];
+  export const OPTIONAL_REQUIRED_KEYS: readonly (keyof FirebaseOptions)[];
+
+  export function normalizeFirebaseConfig(
+    rawConfig: unknown,
+    source: string,
+    loggers?: FirebaseConfigLoggers,
+  ): FirebaseOptions;
+
+  export function tryReadGlobalFirebaseConfig(scope: unknown): { value: unknown; key?: string } | null;
+
+  export function resolveFirebaseConfig(
+    scope: unknown,
+    inlineConfig: FirebaseOptions | null | undefined,
+    loggers?: FirebaseConfigLoggers,
+  ): FirebaseConfigResolveResult;
+
+  export function bootstrap(scope: unknown): FirebaseOptions | null;
+}

--- a/src/types/public__firebase-config.d.ts
+++ b/src/types/public__firebase-config.d.ts
@@ -1,0 +1,53 @@
+export interface FirebaseOptions {
+  apiKey: string;
+  authDomain: string;
+  projectId: string;
+  storageBucket?: string;
+  messagingSenderId?: string;
+  appId: string;
+  measurementId?: string;
+  [key: string]: unknown;
+}
+
+export interface FirebaseConfigBootLogger {
+  log?: (scope: string, message: string) => void;
+  error?: (scope: string, message: string) => void;
+}
+
+export interface FirebaseConfigConsoleLogger {
+  info?: (message: string) => void;
+  error?: (message: string) => void;
+}
+
+export interface FirebaseConfigLoggers {
+  boot?: FirebaseConfigBootLogger;
+  console?: FirebaseConfigConsoleLogger;
+  error?: (message: string) => void;
+  info?: (message: string) => void;
+}
+
+export interface FirebaseConfigResolveResult {
+  config: FirebaseOptions;
+  source: 'window' | 'inline';
+  key?: string;
+}
+
+export declare const WINDOW_CONFIG_KEYS: readonly string[];
+export declare const REQUIRED_KEYS: readonly (keyof FirebaseOptions)[];
+export declare const OPTIONAL_REQUIRED_KEYS: readonly (keyof FirebaseOptions)[];
+
+export declare function normalizeFirebaseConfig(
+  rawConfig: unknown,
+  source: string,
+  loggers?: FirebaseConfigLoggers,
+): FirebaseOptions;
+
+export declare function tryReadGlobalFirebaseConfig(scope: unknown): { value: unknown; key?: string } | null;
+
+export declare function resolveFirebaseConfig(
+  scope: unknown,
+  inlineConfig: FirebaseOptions | null | undefined,
+  loggers?: FirebaseConfigLoggers,
+): FirebaseConfigResolveResult;
+
+export declare function bootstrap(scope: unknown): FirebaseOptions | null;


### PR DESCRIPTION
## Summary
- add a shared Firebase config resolver in `public/firebase-config.js` that validates window overrides, enforces apiKey length, and logs the selected source before bootstrapping globals
- expose helper typings so module code can reuse the browser bootstrapper semantics
- update the TypeScript resolver to consume the shared helper for window/env configs, ensuring consistent validation and logging metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cb26c9a878832e9eb084ac5aef2c9c