### PR TITLE
Refactor Firebase bootstrap to share singleton helper

### DIFF
--- a/public/firebase-bootstrap.js
+++ b/public/firebase-bootstrap.js
@@ -1,0 +1,350 @@
+(function (global) {
+  'use strict';
+
+  const REQUIRED_KEYS = ['apiKey', 'authDomain', 'projectId', 'appId'];
+  const OPTIONAL_KEYS = ['storageBucket', 'messagingSenderId'];
+  const GLOBAL_CONFIG_KEYS = [
+    '__FIREBASE_CONFIG__',
+    'STICKFIGHT_FIREBASE_CONFIG',
+    'STICK_FIGHT_FIREBASE_CONFIG',
+    'STICKFIGHT_FIREBASE_OPTIONS',
+  ];
+
+  const state = {
+    boot: null,
+    config: null,
+    mismatchWarned: false,
+    app: null,
+    auth: null,
+    firestore: null,
+    fieldValue: null,
+    logs: {
+      host: false,
+      init: false,
+      sw: false,
+    },
+  };
+
+  const noopBoot = {
+    log: function () {},
+    error: function () {},
+  };
+
+  function resolveBoot(boot) {
+    if (boot && typeof boot === 'object') {
+      state.boot = boot;
+      return boot;
+    }
+    if (state.boot) {
+      return state.boot;
+    }
+    const globalBoot = global && typeof global.__StickFightBoot === 'object' ? global.__StickFightBoot : null;
+    if (globalBoot) {
+      state.boot = globalBoot;
+      return globalBoot;
+    }
+    state.boot = noopBoot;
+    return state.boot;
+  }
+
+  function log(tag, message, detail) {
+    const boot = state.boot || noopBoot;
+    const logger = boot && typeof boot.log === 'function' ? boot.log.bind(boot) : null;
+    if (logger) {
+      logger(tag, message, detail);
+      return;
+    }
+    if (typeof console !== 'undefined' && console) {
+      const label = '[' + tag + '] ' + message;
+      if (typeof detail !== 'undefined') {
+        if (typeof console.log === 'function') {
+          console.log(label, detail);
+        }
+      } else if (typeof console.log === 'function') {
+        console.log(label);
+      }
+    }
+  }
+
+  function warn(tag, message, detail) {
+    const boot = state.boot || noopBoot;
+    if (boot && typeof boot.log === 'function') {
+      boot.log(tag, message, detail);
+    }
+    if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+      const label = '[' + tag + '] ' + message;
+      if (typeof detail !== 'undefined') {
+        console.warn(label, detail);
+      } else {
+        console.warn(label);
+      }
+    }
+  }
+
+  function configsMatch(a, b) {
+    if (!a || !b) {
+      return true;
+    }
+    const keys = Object.create(null);
+    for (const key in a) {
+      if (Object.prototype.hasOwnProperty.call(a, key)) {
+        keys[key] = true;
+      }
+    }
+    for (const key in b) {
+      if (Object.prototype.hasOwnProperty.call(b, key)) {
+        keys[key] = true;
+      }
+    }
+    for (const key in keys) {
+      if (!Object.prototype.hasOwnProperty.call(keys, key)) {
+        continue;
+      }
+      if (a[key] !== b[key]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function readGlobalConfigCandidate() {
+    if (!global || typeof global !== 'object') {
+      return null;
+    }
+    for (let i = 0; i < GLOBAL_CONFIG_KEYS.length; i += 1) {
+      const key = GLOBAL_CONFIG_KEYS[i];
+      if (key in global && global[key]) {
+        return global[key];
+      }
+    }
+    return null;
+  }
+
+  function validateConfig(raw) {
+    if (!raw || typeof raw !== 'object') {
+      throw new Error('Firebase configuration was not provided.');
+    }
+    const missing = [];
+    const candidate = raw;
+    for (let i = 0; i < REQUIRED_KEYS.length; i += 1) {
+      const key = REQUIRED_KEYS[i];
+      const value = candidate[key];
+      if (typeof value !== 'string' || value.trim() === '') {
+        missing.push(key);
+      }
+    }
+    for (let i = 0; i < OPTIONAL_KEYS.length; i += 1) {
+      const key = OPTIONAL_KEYS[i];
+      const value = candidate[key];
+      if (typeof value === 'undefined') {
+        continue;
+      }
+      if (typeof value !== 'string' || value.trim() === '') {
+        missing.push(key);
+      }
+    }
+    if (missing.length > 0) {
+      throw new Error('Firebase configuration is invalid: missing ' + missing.join(','));
+    }
+    return {
+      apiKey: candidate.apiKey,
+      authDomain: candidate.authDomain,
+      projectId: candidate.projectId,
+      storageBucket: candidate.storageBucket,
+      messagingSenderId: candidate.messagingSenderId,
+      appId: candidate.appId,
+      measurementId: candidate.measurementId,
+    };
+  }
+
+  function logHostOnce(config) {
+    if (state.logs.host) {
+      return;
+    }
+    state.logs.host = true;
+
+    let origin = 'unknown';
+    let route = 'unknown';
+    try {
+      if (typeof location !== 'undefined' && location) {
+        origin = typeof location.origin === 'string' ? location.origin : origin;
+        route = typeof location.pathname === 'string' ? location.pathname : route;
+      }
+    } catch (error) {
+      // Ignore failures when reading location.
+    }
+
+    log('HOST', 'origin=' + origin + ' route=' + route + ' authDomain=' + config.authDomain);
+  }
+
+  function logServiceWorkerOnce() {
+    if (state.logs.sw) {
+      return;
+    }
+    state.logs.sw = true;
+
+    let status = 'unsupported';
+    let controller = 'none';
+    try {
+      if (typeof navigator !== 'undefined' && navigator && 'serviceWorker' in navigator) {
+        status = 'supported';
+        const sw = navigator.serviceWorker;
+        controller = sw && sw.controller ? 'controller' : 'none';
+      }
+    } catch (error) {
+      status = 'error';
+    }
+
+    log('SW', 'status=' + status + ' controller=' + controller);
+  }
+
+  function logInitOnce(namespace, action) {
+    if (state.logs.init) {
+      return;
+    }
+    state.logs.init = true;
+
+    const version = namespace && typeof namespace.SDK_VERSION === 'string' ? namespace.SDK_VERSION : 'unknown';
+    const appsCount = namespace && namespace.apps && typeof namespace.apps.length === 'number' ? namespace.apps.length : 0;
+    log('INIT', 'firebase-app ' + action + ' sdk=' + version + ' apps=' + appsCount);
+  }
+
+  function warnConfigMismatch(existingConfig, expectedConfig) {
+    if (state.mismatchWarned) {
+      return;
+    }
+    state.mismatchWarned = true;
+    const expectedProject = expectedConfig && expectedConfig.projectId ? expectedConfig.projectId : 'unknown';
+    const existingProject = existingConfig && existingConfig.projectId ? existingConfig.projectId : 'unknown';
+    warn('INIT', 'firebase-config-mismatch reuse-existing-app expected=' + expectedProject + ' existing=' + existingProject);
+  }
+
+  function ensureConfig(boot) {
+    resolveBoot(boot);
+    const raw = readGlobalConfigCandidate();
+    if (!raw && state.config) {
+      return state.config;
+    }
+    if (!raw && !state.config) {
+      throw new Error('Firebase configuration was not provided.');
+    }
+
+    const validated = validateConfig(raw);
+    if (!state.config) {
+      state.config = validated;
+      logHostOnce(validated);
+      logServiceWorkerOnce();
+      return state.config;
+    }
+
+    if (!configsMatch(state.config, validated)) {
+      warnConfigMismatch(state.config, validated);
+    }
+    return state.config;
+  }
+
+  function getFirebaseNamespace() {
+    if (typeof global === 'undefined' || !global) {
+      throw new Error('Firebase SDK is not available in this environment.');
+    }
+    const namespace = global.firebase;
+    if (!namespace) {
+      throw new Error('Firebase SDK failed to load.');
+    }
+    return namespace;
+  }
+
+  function ensureFirebaseApp(boot) {
+    resolveBoot(boot);
+    if (state.app) {
+      return state.app;
+    }
+    const namespace = getFirebaseNamespace();
+    const config = ensureConfig(boot);
+
+    const apps = namespace.apps && typeof namespace.apps.length === 'number' ? namespace.apps : [];
+    if (apps && apps.length > 0) {
+      const existingApp = typeof namespace.app === 'function' ? namespace.app() : apps[0];
+      const existingConfig = existingApp && existingApp.options ? existingApp.options : null;
+      if (existingConfig && !configsMatch(existingConfig, config)) {
+        warnConfigMismatch(existingConfig, config);
+      }
+      state.app = existingApp;
+      logInitOnce(namespace, 'reused');
+      return state.app;
+    }
+
+    if (typeof namespace.initializeApp !== 'function') {
+      throw new Error('Firebase initializeApp method is not available.');
+    }
+
+    state.app = namespace.initializeApp(config);
+    logInitOnce(namespace, 'created');
+    return state.app;
+  }
+
+  function ensureAuth(boot) {
+    resolveBoot(boot);
+    if (state.auth) {
+      return state.auth;
+    }
+    const namespace = getFirebaseNamespace();
+    if (typeof namespace.auth !== 'function') {
+      throw new Error('Firebase Auth SDK is not available.');
+    }
+    ensureFirebaseApp(boot);
+    state.auth = namespace.auth();
+    return state.auth;
+  }
+
+  function ensureFirestore(boot) {
+    resolveBoot(boot);
+    if (state.firestore) {
+      return state.firestore;
+    }
+    const namespace = getFirebaseNamespace();
+    if (typeof namespace.firestore !== 'function') {
+      throw new Error('Firebase Firestore SDK is not available.');
+    }
+    ensureFirebaseApp(boot);
+    state.firestore = namespace.firestore();
+    state.fieldValue = namespace.firestore && namespace.firestore.FieldValue ? namespace.firestore.FieldValue : null;
+    return state.firestore;
+  }
+
+  function ensureFieldValue(boot) {
+    ensureFirestore(boot);
+    return state.fieldValue;
+  }
+
+  function bootstrap(boot) {
+    const resolvedBoot = resolveBoot(boot);
+    const namespace = getFirebaseNamespace();
+    const app = ensureFirebaseApp(resolvedBoot);
+    const auth = ensureAuth(resolvedBoot);
+    const firestore = ensureFirestore(resolvedBoot);
+    const config = ensureConfig(resolvedBoot);
+
+    return {
+      firebase: namespace,
+      app: app,
+      auth: auth,
+      firestore: firestore,
+      fieldValue: state.fieldValue,
+      config: config,
+    };
+  }
+
+  const api = {
+    bootstrap: bootstrap,
+    getApp: ensureFirebaseApp,
+    getAuth: ensureAuth,
+    getFirestore: ensureFirestore,
+    getFieldValue: ensureFieldValue,
+    getConfig: ensureConfig,
+  };
+
+  if (!global.__StickFightFirebaseBootstrap) {
+    global.__StickFightFirebaseBootstrap = api;
+  }
+})(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : this);

--- a/public/index.html
+++ b/public/index.html
@@ -149,6 +149,7 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js" defer></script>
     <script src="joydiag-config.js" defer></script>
     <script src="firebase-config.js" defer></script>
+    <script src="firebase-bootstrap.js" defer></script>
     <script src="net.js" defer></script>
     <script src="net-server.js" defer></script>
     <script src="netplay.js" defer></script>

--- a/public/net.js
+++ b/public/net.js
@@ -56,29 +56,38 @@
     listening: false,
   };
 
-  const firebaseNamespace = () => (typeof global.firebase !== 'undefined' ? global.firebase : null);
+  const FirebaseBootstrap =
+    global && typeof global.__StickFightFirebaseBootstrap === 'object'
+      ? global.__StickFightFirebaseBootstrap
+      : null;
 
-  const getFirebaseConfig = () => {
-    if (typeof global === 'undefined') {
-      return null;
+  let firebaseBootstrapEnv = null;
+
+  const ensureFirebaseEnv = () => {
+    if (NETWORK_DISABLED) {
+      throw new Error('Networking disabled by query flags.');
     }
-    if (global.__FIREBASE_CONFIG__) {
-      return global.__FIREBASE_CONFIG__;
+    if (firebaseBootstrapEnv) {
+      return firebaseBootstrapEnv;
     }
-    if (global.STICK_FIGHT_FIREBASE_CONFIG) {
-      return global.STICK_FIGHT_FIREBASE_CONFIG;
+    if (!FirebaseBootstrap || typeof FirebaseBootstrap.bootstrap !== 'function') {
+      throw new Error('Firebase bootstrap helper unavailable.');
     }
-    if (global.STICKFIGHT_FIREBASE_CONFIG) {
-      return global.STICKFIGHT_FIREBASE_CONFIG;
-    }
-    if (global.STICKFIGHT_FIREBASE_OPTIONS) {
-      return global.STICKFIGHT_FIREBASE_OPTIONS;
-    }
-    return null;
+    firebaseBootstrapEnv = FirebaseBootstrap.bootstrap(Boot);
+    return firebaseBootstrapEnv;
   };
 
   const describeFirebaseConfig = () => {
-    const config = getFirebaseConfig();
+    let config = null;
+    try {
+      if (FirebaseBootstrap && typeof FirebaseBootstrap.getConfig === 'function') {
+        config = FirebaseBootstrap.getConfig(Boot);
+      } else if (firebaseBootstrapEnv) {
+        config = firebaseBootstrapEnv.config;
+      }
+    } catch (error) {
+      config = null;
+    }
     const projectId = config && typeof config.projectId === 'string' ? config.projectId : 'missing';
     const authDomain = config && typeof config.authDomain === 'string' ? config.authDomain : 'missing';
     const apiKey = config && typeof config.apiKey === 'string' ? config.apiKey : '';
@@ -100,35 +109,31 @@
     bootLog('CFG', message);
   };
 
-  const ensureFirebaseApp = () => {
-    if (NETWORK_DISABLED) {
-      throw new Error('Networking disabled by query flags.');
+  const firebaseNamespace = () => {
+    if (firebaseBootstrapEnv && firebaseBootstrapEnv.firebase) {
+      return firebaseBootstrapEnv.firebase;
     }
-    const firebase = firebaseNamespace();
-    if (!firebase) {
-      throw new Error('Firebase SDK failed to load.');
+    if (!FirebaseBootstrap || typeof FirebaseBootstrap.bootstrap !== 'function') {
+      return typeof global.firebase !== 'undefined' ? global.firebase : null;
     }
-    const config = getFirebaseConfig();
-    if (!config) {
-      throw new Error('Firebase configuration was not provided.');
+    try {
+      return ensureFirebaseEnv().firebase;
+    } catch (error) {
+      return typeof global.firebase !== 'undefined' ? global.firebase : null;
     }
-    if (!firebase.apps || firebase.apps.length === 0) {
-      firebase.initializeApp(config);
-    }
-    return firebase;
   };
 
   const ensureFirestore = () => {
     if (netState.firestore) {
       return netState.firestore;
     }
-    const firebase = ensureFirebaseApp();
-    if (typeof firebase.firestore !== 'function') {
+    const env = ensureFirebaseEnv();
+    const firestoreInstance = env && env.firestore ? env.firestore : null;
+    if (!firestoreInstance) {
       throw new Error('Firestore SDK is not available.');
     }
-    const firestoreInstance = firebase.firestore();
     netState.firestore = firestoreInstance;
-    netState.fieldValue = firebase.firestore.FieldValue || null;
+    netState.fieldValue = env.fieldValue || (env.firebase && env.firebase.firestore ? env.firebase.firestore.FieldValue : null);
     return firestoreInstance;
   };
 
@@ -143,15 +148,12 @@ function ensureAuth() {
   }
   if (_authInstance) return _authInstance;
 
-  const firebase = ensureFirebaseApp
-    ? ensureFirebaseApp()                   // your existing helper
-    : (window.firebase || firebaseNamespace && firebaseNamespace());
-
-  if (!firebase || typeof firebase.auth !== 'function') {
+  const env = ensureFirebaseEnv();
+  if (!env || !env.auth) {
     throw new Error('Firebase Auth SDK is not available.');
   }
 
-  _authInstance = firebase.auth();
+  _authInstance = env.auth;
   bootLog('AUTH', 'auth-instance-ready');
   return _authInstance;
 }


### PR DESCRIPTION
## Summary
- add a shared Firebase bootstrap helper that validates config, logs host/init/SW once, and reuses singletons
- refactor main and net entrypoints to rely on the shared helper instead of inline initialization
- load the bootstrap helper in the shell so every caller shares the same Firebase app/auth/firestore instances

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2d6f5510832ebedc5593cba0ccee