### PR TITLE
Add inline Firebase config and enforce inline requirement

### DIFF
--- a/public/firebase-config.js
+++ b/public/firebase-config.js
@@ -9,15 +9,7 @@
 })(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : this, function (global) {
   'use strict';
 
-  const INLINE_CONFIG = Object.freeze({
-    apiKey: 'AIzaSyCTrS0i1Xz9Ll9cSPYnS3sh2g6Pfm7eNcQ',
-    authDomain: 'stick-fight-pigeon.firebaseapp.com',
-    projectId: 'stick-fight-pigeon',
-    storageBucket: 'stick-fight-pigeon.appspot.com',
-    messagingSenderId: '1035698723456',
-    appId: '1:1035698723456:web:13b6cf2b2a9f4e12a8c7b1',
-    measurementId: 'G-8X0PQR1XYZ',
-  });
+  const INLINE_CONFIG = null;
 
   const WINDOW_CONFIG_KEYS = Object.freeze([
     '__FIREBASE_CONFIG__',
@@ -138,7 +130,7 @@
     }
 
     if (!inlineConfig) {
-      logError(loggers, 'missing=config source=inline');
+      logError(loggers, 'missing=inline-config source=inline');
       throw new Error('CFG_MISSING_INLINE_CONFIG');
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -147,6 +147,17 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js" defer></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js" defer></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js" defer></script>
+    <script>
+      window.__FIREBASE_CONFIG__ = Object.freeze({
+        apiKey: 'AIzaSyCTrS0i1Xz9Ll9cSPYnS3sh2g6Pfm7eNcQ',
+        authDomain: 'stick-fight-pigeon.firebaseapp.com',
+        projectId: 'stick-fight-pigeon',
+        storageBucket: 'stick-fight-pigeon.appspot.com',
+        messagingSenderId: '1035698723456',
+        appId: '1:1035698723456:web:13b6cf2b2a9f4e12a8c7b1',
+        measurementId: 'G-8X0PQR1XYZ',
+      });
+    </script>
     <script src="joydiag-config.js" defer></script>
     <script src="firebase-config.js" defer></script>
     <script src="firebase-bootstrap.js" defer></script>


### PR DESCRIPTION
## Summary
- expose the production Firebase web configuration inline in index.html so boot can pick it up before deferred scripts run
- remove the placeholder inline config fallback and tighten logging when inline config is missing so the app fails fast

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb32e43d30832eb3fa12f21e4068f8