### PR TITLE
Improve firebase config resolution sources

### DIFF
--- a/src/types/public__firebase-config.d.ts
+++ b/src/types/public__firebase-config.d.ts
@@ -27,8 +27,8 @@ export interface FirebaseConfigLoggers {
 }
 
 export interface FirebaseConfigResolveResult {
-  config: FirebaseOptions;
-  source: 'window' | 'inline';
+  config: FirebaseOptions | null;
+  source: 'firebase-init' | 'window' | 'inline' | 'none';
   key?: string;
 }
 


### PR DESCRIPTION
## Summary
- check the initialized Firebase app before consulting window globals when resolving the config
- gate inline configuration behind the `useInline=1` query flag and relax missing-config errors in safe mode
- adjust the Firebase config resolve result type definitions to cover new sources and null configs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb36121134832ea9ea9b2f456233d4