### PR TITLE
Skip service worker interactions when debug flag is set

### DIFF
--- a/public/firebase-bootstrap.js
+++ b/public/firebase-bootstrap.js
@@ -177,11 +177,22 @@
     log('HOST', 'origin=' + origin + ' route=' + route + ' authDomain=' + config.authDomain);
   }
 
-  function logServiceWorkerOnce() {
+  function logServiceWorkerOnce(boot) {
     if (state.logs.sw) {
       return;
     }
     state.logs.sw = true;
+
+    const resolvedBoot = resolveBoot(boot);
+    const bootFlags =
+      resolvedBoot && resolvedBoot.flags && typeof resolvedBoot.flags === 'object'
+        ? resolvedBoot.flags
+        : null;
+    const debugMode = !!(bootFlags && bootFlags.debug);
+    if (debugMode) {
+      log('SW', 'registered=no (debug)');
+      return;
+    }
 
     let status = 'unsupported';
     let controller = 'none';
@@ -221,6 +232,7 @@
 
   function ensureConfig(boot) {
     resolveBoot(boot);
+    logServiceWorkerOnce(boot);
     const raw = readGlobalConfigCandidate();
     if (!raw && state.config) {
       return state.config;
@@ -233,7 +245,7 @@
     if (!state.config) {
       state.config = validated;
       logHostOnce(validated);
-      logServiceWorkerOnce();
+      logServiceWorkerOnce(boot);
       return state.config;
     }
 

--- a/public/main.js
+++ b/public/main.js
@@ -57,17 +57,26 @@
         console.error('[CFG][ERR] ' + message);
       }
 
-      const sw = typeof navigator !== 'undefined' && navigator && navigator.serviceWorker ? navigator.serviceWorker : null;
-      if (sw && sw.ready && typeof sw.ready.then === 'function') {
-        sw.ready
-          .then((registration) => {
-            if (registration && typeof registration.update === 'function') {
-              logDiagnostic('CFG', 'retry: requested service worker update');
-              return registration.update();
-            }
-            return null;
-          })
-          .catch(() => undefined);
+      const bootFlags =
+        Boot && Boot.flags && typeof Boot.flags === 'object' ? Boot.flags : null;
+      const debugMode = !!(bootFlags && bootFlags.debug);
+
+      if (!debugMode) {
+        const sw =
+          typeof navigator !== 'undefined' && navigator && navigator.serviceWorker
+            ? navigator.serviceWorker
+            : null;
+        if (sw && sw.ready && typeof sw.ready.then === 'function') {
+          sw.ready
+            .then((registration) => {
+              if (registration && typeof registration.update === 'function') {
+                logDiagnostic('CFG', 'retry: requested service worker update');
+                return registration.update();
+              }
+              return null;
+            })
+            .catch(() => undefined);
+        }
       }
 
       logDiagnostic('CFG', 'hint: Shift+Reload to bypass stale service worker');


### PR DESCRIPTION
## Summary
- short-circuit service worker logging when Boot.flags.debug is enabled so we emit a debug registration message once
- avoid requesting service worker updates during config failure recovery while debug mode is active

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb3653bd50832e83d84bcad4e87ea8