### PR TITLE
Add debug log drawer with clipboard support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -141,6 +141,94 @@
       .boot-overlay__error[hidden] {
         display: none;
       }
+
+      #boot-debug-drawer {
+        position: fixed;
+        z-index: 10000;
+        bottom: calc(var(--safe-area-inset-bottom) + 16px);
+        right: calc(var(--safe-area-inset-right) + 16px);
+        width: min(360px, 40vw);
+        max-width: 420px;
+        font-family: 'Segoe UI', Roboto, sans-serif;
+        color: #fff;
+        background: rgba(10, 10, 15, 0.88);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 12px;
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+        backdrop-filter: blur(6px);
+        overflow: hidden;
+        pointer-events: auto;
+      }
+
+      #boot-debug-drawer .boot-debug-drawer__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 10px 12px;
+        background: rgba(255, 255, 255, 0.05);
+      }
+
+      #boot-debug-drawer button {
+        font-family: inherit;
+        font-size: 12px;
+        line-height: 1.2;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        padding: 6px 12px;
+        color: #fff;
+        background: rgba(0, 0, 0, 0.35);
+        cursor: pointer;
+        pointer-events: auto;
+      }
+
+      #boot-debug-drawer button:focus {
+        outline: 2px solid rgba(0, 168, 255, 0.6);
+        outline-offset: 2px;
+      }
+
+      #boot-debug-drawer button:hover {
+        background: rgba(255, 255, 255, 0.15);
+      }
+
+      #boot-debug-drawer .boot-debug-drawer__body {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        padding: 12px;
+      }
+
+      #boot-debug-drawer[data-open='false'] .boot-debug-drawer__body {
+        display: none;
+      }
+
+      #boot-debug-drawer .boot-debug-drawer__textarea {
+        width: 100%;
+        min-height: 160px;
+        max-height: 40vh;
+        resize: vertical;
+        border-radius: 8px;
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        background: rgba(0, 0, 0, 0.5);
+        color: #e2e8f0;
+        padding: 10px;
+        font-family: 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', monospace;
+        font-size: 12px;
+        line-height: 1.4;
+        pointer-events: auto;
+        -webkit-user-select: text;
+        user-select: text;
+        overflow: auto;
+        box-sizing: border-box;
+      }
+
+      #boot-debug-drawer .boot-debug-drawer__textarea:focus {
+        outline: 2px solid rgba(0, 168, 255, 0.45);
+        outline-offset: 2px;
+      }
     </style>
     <script src="boot.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>


### PR DESCRIPTION
## Summary
- add a boot-time debug drawer that mirrors log entries and exposes toggle/copy controls
- retain up to 200 timestamped messages for review and make them available via keyboard shortcut or clipboard helpers
- style the drawer so it anchors bottom-right with pointer interactions while keeping the original boot badge untouched

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb3e561f1c832e933d8c43a77d3dfa