### PR TITLE
Add shared Firebase bootstrap helper

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -53,6 +53,9 @@
     if (scope && typeof scope.__StickFightFirebaseBootstrap === 'object') {
       return scope.__StickFightFirebaseBootstrap;
     }
+    if (scope && typeof scope.FirebaseBootstrap === 'object') {
+      return scope.FirebaseBootstrap;
+    }
     return null;
   })();
 

--- a/public/net.js
+++ b/public/net.js
@@ -64,10 +64,18 @@
     listening: false,
   };
 
-  const FirebaseBootstrap =
-    global && typeof global.__StickFightFirebaseBootstrap === 'object'
-      ? global.__StickFightFirebaseBootstrap
-      : null;
+  const FirebaseBootstrap = (function resolveFirebaseBootstrap(scope) {
+    if (!scope) {
+      return null;
+    }
+    if (typeof scope.__StickFightFirebaseBootstrap === 'object') {
+      return scope.__StickFightFirebaseBootstrap;
+    }
+    if (typeof scope.FirebaseBootstrap === 'object') {
+      return scope.FirebaseBootstrap;
+    }
+    return null;
+  })(global);
 
   const FirebaseConfigModule =
     global && typeof global.__StickFightFirebaseConfigModule === 'object'


### PR DESCRIPTION
## Summary
- register the firebase bootstrap helper as `__StickFightFirebaseBootstrap` while keeping the legacy export
- add a cached `bootstrap` payload that returns the firebase, firestore, and field value instances expected by the app
- update the main and net entry points to resolve the shared bootstrap helper before using it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb608b2a40832eafbf9f545daeaf16