### PR TITLE
Configure Firebase hosting target

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,14 @@
 {
   "projects": {
     "default": "stick-fight-pigeon"
+  },
+  "targets": {
+    "stick-fight-pigeon": {
+      "hosting": {
+        "stick-fight-pigeon": [
+          "stick-fight-pigeon"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- define the `stick-fight-pigeon` hosting target in `.firebaserc`

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cb7fb4671c832e89d7806a0ecc5409