### PR TITLE
Update hosting deploy script

### DIFF
--- a/docs/firebase.md
+++ b/docs/firebase.md
@@ -12,6 +12,16 @@ firebase deploy --only firestore:rules
 
 This command requires the Firebase CLI to be authenticated against the `stick-fight-pigeon` project.
 
+## Deploy updated Hosting assets
+
+Run the following command to build Cloud Functions and release the latest Hosting build for the `stick-fight-pigeon` site:
+
+```bash
+npm run deploy
+```
+
+This is the canonical command for publishing Hosting updates and ensures only the `stick-fight-pigeon` site is updated.
+
 ## Grant admin access
 
 Administrative actions in the in-game panel require a custom claim named `admin` (or `stickfightAdmin`) on the Firebase Authentication user. You can assign the claim with the Firebase CLI or via an admin SDK script. Example using the CLI:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "node --test tests",
     "build:functions": "npm --prefix functions run build",
-    "deploy": "npm run build:functions && firebase deploy"
+    "deploy": "npm run build:functions && firebase deploy --only hosting:stick-fight-pigeon"
   },
   "dependencies": {
     "firebase-admin": "^11.11.0"


### PR DESCRIPTION
## Summary
- limit the npm `deploy` script to build the Functions bundle and deploy only the stick-fight-pigeon Hosting site
- document `npm run deploy` as the canonical Hosting release command in the Firebase guide

## Testing
- npm run deploy *(fails: missing Firebase Functions dependencies because npm registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb80981b6c832e86fbf2d3ed0c47f0