### PR TITLE
Add stage center line overlay

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -2920,6 +2920,9 @@ this.netOverlay = (typeof this.netOverlay !== 'undefined') ? this.netOverlay : n
       if (!this.stageLine && this.add && typeof this.add.graphics === 'function') {
         this.stageLine = this.add.graphics();
         this.stageLine.setDepth(1000);
+        if (this.stageLine.setScrollFactor) {
+          this.stageLine.setScrollFactor(0);
+        }
       }
 
       if (this.diagnosticsActive() && typeof console !== 'undefined' && console) {


### PR DESCRIPTION
## Summary
- lock the stage center line graphics to the camera so the mid-room guide stays aligned with the play area

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb86ae60f0832ead26571410cc9bf6