### PR TITLE
Open admin UI and add navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,14 +28,35 @@
         user-select: none;
       }
 
-      #game-root {
+      #room-border {
         position: fixed;
         top: var(--safe-area-inset-top);
         right: var(--safe-area-inset-right);
         bottom: var(--safe-area-inset-bottom);
         left: var(--safe-area-inset-left);
-        width: auto;
-        height: auto;
+        border: 2px solid #fff;
+        border-radius: 8px;
+        background: #000;
+        overflow: hidden;
+        box-sizing: border-box;
+      }
+
+      #game-root {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      .stage-line {
+        position: absolute;
+        top: 50%;
+        left: 0;
+        right: 0;
+        border-top: 2px solid #fff;
+        opacity: 0.85;
+        pointer-events: none;
+        transform: translateY(-1px);
       }
 
       canvas {
@@ -253,6 +274,9 @@
       <ul class="boot-overlay__status" data-boot-status></ul>
       <pre class="boot-overlay__error" data-boot-error hidden></pre>
     </div>
-    <div id="game-root"></div>
+    <div id="room-border">
+      <div class="stage-line"></div>
+      <div id="game-root"></div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove client-side admin password/claims gating and always allow the admin view to render
- add a shared top navigation/header and hash-based router to switch Lobby, Admin, and Join views
- introduce a Join Table flow, room list join buttons, and a centered stage line wrapper around the game canvas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb889358c8832eae8abc0290dcbdc5