### PR TITLE
Add realtime room presence rendering

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,44 @@
         height: 100%;
       }
 
+      #view-room {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        padding: 16px;
+        box-sizing: border-box;
+      }
+
+      .room-wrap {
+        position: relative;
+        width: 800px;
+        height: 440px;
+        margin: 0 auto;
+      }
+
+      .room-canvas {
+        display: block;
+        width: 800px;
+        height: 440px;
+        background: #000;
+        border: 2px solid #fff;
+        border-radius: 8px;
+      }
+
+      .room-stage-line {
+        position: absolute;
+        top: 50%;
+        left: 0;
+        right: 0;
+        height: 0;
+        border-top: 2px solid #fff;
+        pointer-events: none;
+        opacity: 0.9;
+        transform: translateY(-1px);
+      }
+
       .stage-line {
         position: absolute;
         top: 50%;

--- a/src/net/controls.ts
+++ b/src/net/controls.ts
@@ -1,0 +1,88 @@
+import { getPlayerDoc } from './firestoreCompat';
+import type { PlayerPresence } from './playersStore';
+
+type ControlsOptions = {
+  roomCode: string;
+  uid: string;
+  getPlayer: (uid: string) => PlayerPresence | undefined;
+  setLocalPos: (payload: { x: number; y: number; dir: 'L' | 'R' }) => void;
+};
+
+type DetachControls = () => void;
+
+const MOVE_SPEED = 2.5;
+const WRITE_INTERVAL_MS = 100;
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+export function attachControls(options: ControlsOptions): DetachControls {
+  const { roomCode, uid, getPlayer, setLocalPos } = options;
+  const keys = new Set<string>();
+  const ref = getPlayerDoc(roomCode, uid);
+  let lastWrite = 0;
+  let rafId: number | null = null;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    keys.add(event.key);
+  };
+
+  const handleKeyUp = (event: KeyboardEvent) => {
+    keys.delete(event.key);
+  };
+
+  const tick = () => {
+    const player = getPlayer(uid);
+    const now = typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+
+    if (player) {
+      let dx = 0;
+      let dy = 0;
+      if (keys.has('ArrowLeft') || keys.has('a') || keys.has('A')) {
+        dx -= 1;
+      }
+      if (keys.has('ArrowRight') || keys.has('d') || keys.has('D')) {
+        dx += 1;
+      }
+      if (keys.has('ArrowUp') || keys.has('w') || keys.has('W')) {
+        dy -= 1;
+      }
+      if (keys.has('ArrowDown') || keys.has('s') || keys.has('S')) {
+        dy += 1;
+      }
+
+      if (dx !== 0 || dy !== 0) {
+        const magnitude = Math.hypot(dx, dy) || 1;
+        const normX = dx / magnitude;
+        const normY = dy / magnitude;
+        const nextDir: 'L' | 'R' = normX < 0 ? 'L' : normX > 0 ? 'R' : player.dir;
+        const nextX = clamp(player.x + normX * MOVE_SPEED, 8, 792);
+        const nextY = clamp(player.y + normY * MOVE_SPEED, 8, 432);
+
+        setLocalPos({ x: nextX, y: nextY, dir: nextDir });
+
+        const moved = Math.abs(nextX - player.x) + Math.abs(nextY - player.y) > 0.5 || nextDir !== player.dir;
+        if (moved && now - lastWrite >= WRITE_INTERVAL_MS) {
+          lastWrite = now;
+          void ref.update({ x: nextX, y: nextY, dir: nextDir }).catch(() => undefined);
+        }
+      }
+    }
+
+    rafId = requestAnimationFrame(tick);
+  };
+
+  window.addEventListener('keydown', handleKeyDown);
+  window.addEventListener('keyup', handleKeyUp);
+  rafId = requestAnimationFrame(tick);
+
+  return () => {
+    window.removeEventListener('keydown', handleKeyDown);
+    window.removeEventListener('keyup', handleKeyUp);
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+}

--- a/src/net/firestoreCompat.ts
+++ b/src/net/firestoreCompat.ts
@@ -1,0 +1,79 @@
+const FIRESTORE_PATH_PREFIX = 'rooms';
+
+export type FirestoreNamespace = {
+  firestore?: () => FirestoreCompat;
+};
+
+export type FirestoreCompat = {
+  doc: (path: string) => FirestoreDocRef;
+  collection: (path: string) => FirestoreCollectionRef;
+};
+
+export type FirestoreDocRef = {
+  set: (data: Record<string, unknown>, options?: Record<string, unknown>) => Promise<unknown>;
+  update: (data: Record<string, unknown>) => Promise<unknown>;
+  delete: () => Promise<unknown>;
+  onSnapshot?: (...args: unknown[]) => unknown;
+};
+
+export type FirestoreCollectionRef = {
+  doc: (id: string) => FirestoreDocRef;
+  onSnapshot: (callback: (...args: unknown[]) => unknown) => () => void;
+  where?: (...args: unknown[]) => unknown;
+};
+
+function getFirebaseNamespace(): FirestoreNamespace {
+  if (typeof window === 'undefined') {
+    throw new Error('Firestore SDK is not available in this environment.');
+  }
+  const firebase = (window as Record<string, unknown>).firebase as FirestoreNamespace | undefined;
+  if (!firebase || typeof firebase.firestore !== 'function') {
+    throw new Error('Firestore SDK failed to load.');
+  }
+  return firebase;
+}
+
+export function getFirestore(): FirestoreCompat {
+  const firebase = getFirebaseNamespace();
+  const firestoreFactory = firebase.firestore;
+  if (typeof firestoreFactory !== 'function') {
+    throw new Error('Firestore SDK is not available.');
+  }
+  return firestoreFactory();
+}
+
+export function getServerTimestamp(): unknown {
+  const firebase = getFirebaseNamespace();
+  const namespace = firebase.firestore as unknown as { FieldValue?: { serverTimestamp?: () => unknown } };
+  const serverTimestampFn = namespace && namespace.FieldValue && namespace.FieldValue.serverTimestamp;
+  if (typeof serverTimestampFn === 'function') {
+    return serverTimestampFn();
+  }
+  return new Date();
+}
+
+export function getPlayersCollection(roomCode: string): FirestoreCollectionRef {
+  const firestore = getFirestore();
+  if (typeof firestore.collection === 'function') {
+    const roomsCollection = firestore.collection(FIRESTORE_PATH_PREFIX);
+    if (roomsCollection && typeof roomsCollection.doc === 'function') {
+      const roomRef = roomsCollection.doc(roomCode);
+      if (roomRef && typeof roomRef.collection === 'function') {
+        return roomRef.collection('players') as unknown as FirestoreCollectionRef;
+      }
+    }
+  }
+  throw new Error('Failed to access players collection.');
+}
+
+export function getPlayerDoc(roomCode: string, uid: string): FirestoreDocRef {
+  const firestore = getFirestore();
+  if (typeof firestore.doc === 'function') {
+    return firestore.doc(`${FIRESTORE_PATH_PREFIX}/${roomCode}/players/${uid}`);
+  }
+  const players = getPlayersCollection(roomCode);
+  if (players && typeof players.doc === 'function') {
+    return players.doc(uid);
+  }
+  throw new Error('Firestore API does not support document access.');
+}

--- a/src/net/playersStore.ts
+++ b/src/net/playersStore.ts
@@ -1,0 +1,74 @@
+import { getPlayersCollection } from './firestoreCompat';
+
+export type PlayerPresence = {
+  uid: string;
+  name?: string;
+  color?: string;
+  x: number;
+  y: number;
+  dir: 'L' | 'R';
+  ts?: unknown;
+};
+
+export type PlayerMap = Map<string, PlayerPresence>;
+
+type SnapshotDoc = {
+  id: string;
+  data: () => Record<string, unknown> | undefined;
+};
+
+type QuerySnapshot = {
+  forEach: (callback: (doc: SnapshotDoc) => void) => void;
+};
+
+type Unsubscribe = () => void;
+
+type OnSnapshotCallback = (snapshot: QuerySnapshot) => void;
+
+type PlayersCollection = ReturnType<typeof getPlayersCollection> & {
+  onSnapshot: (callback: OnSnapshotCallback, onError?: (error: unknown) => void) => Unsubscribe;
+};
+
+function normalizePresence(doc: SnapshotDoc): PlayerPresence {
+  const data = doc.data() || {};
+  const uid = typeof data.uid === 'string' && data.uid.trim() ? data.uid : doc.id;
+  const name = typeof data.name === 'string' ? data.name : undefined;
+  const color = typeof data.color === 'string' ? data.color : undefined;
+  const x = typeof data.x === 'number' ? data.x : 0;
+  const y = typeof data.y === 'number' ? data.y : 0;
+  const dirValue = data.dir === 'L' || data.dir === 'R' ? data.dir : 'R';
+  const presence: PlayerPresence = {
+    uid,
+    name,
+    color,
+    x,
+    y,
+    dir: dirValue,
+  };
+  if (typeof data.ts !== 'undefined') {
+    presence.ts = data.ts;
+  }
+  return presence;
+}
+
+export function watchPlayers(
+  roomCode: string,
+  onChange: (players: PlayerMap) => void,
+): () => void {
+  const collection = getPlayersCollection(roomCode) as PlayersCollection;
+  const unsubscribe = collection.onSnapshot((snapshot) => {
+    const map: PlayerMap = new Map();
+    snapshot.forEach((doc) => {
+      const presence = normalizePresence(doc);
+      map.set(doc.id, presence);
+    });
+    onChange(map);
+  });
+  return () => {
+    try {
+      unsubscribe();
+    } catch (error) {
+      // ignore unsubscribe failure
+    }
+  };
+}

--- a/src/net/presence.ts
+++ b/src/net/presence.ts
@@ -1,0 +1,127 @@
+import { getPlayerDoc, getServerTimestamp } from './firestoreCompat';
+
+type PresenceOptions = {
+  name?: string;
+  color?: string;
+};
+
+type SpawnPoint = {
+  x: number;
+  y: number;
+};
+
+type EnterRoomHandle = {
+  ref: ReturnType<typeof getPlayerDoc>;
+  cleanup: () => Promise<void>;
+  meta: { name: string; color: string; spawn: SpawnPoint };
+};
+
+const HEARTBEAT_INTERVAL_MS = 15000;
+
+const DEFAULT_COLORS = ['#37A9FF', '#FF6B6B', '#FFD166', '#06D6A0', '#C792EA', '#FFA500'];
+
+function randomSpawn(): SpawnPoint {
+  const padding = 20;
+  const width = 800;
+  const height = 440;
+  return {
+    x: padding + Math.random() * (width - 2 * padding),
+    y: padding + Math.random() * (height - 2 * padding),
+  };
+}
+
+function randomColor(): string {
+  const index = Math.floor(Math.random() * DEFAULT_COLORS.length);
+  return DEFAULT_COLORS[index] ?? '#37A9FF';
+}
+
+export async function enterRoom(
+  roomCode: string,
+  uid: string,
+  options: PresenceOptions = {},
+): Promise<EnterRoomHandle> {
+  const ref = getPlayerDoc(roomCode, uid);
+  const spawn = randomSpawn();
+  const color = typeof options.color === 'string' && options.color.trim() ? options.color : randomColor();
+  const name = typeof options.name === 'string' && options.name.trim() ? options.name : 'Player';
+
+  const payload = {
+    uid,
+    name,
+    color,
+    x: spawn.x,
+    y: spawn.y,
+    dir: 'R',
+    ts: getServerTimestamp(),
+  };
+
+  await ref.set(payload, { merge: true });
+
+  let stopped = false;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  const sendHeartbeat = () => {
+    if (stopped) {
+      return Promise.resolve();
+    }
+    try {
+      return ref.update({ ts: getServerTimestamp() }).catch(() => undefined);
+    } catch (error) {
+      return Promise.resolve();
+    }
+  };
+
+  heartbeatTimer = setInterval(() => {
+    void sendHeartbeat();
+  }, HEARTBEAT_INTERVAL_MS);
+
+  const unloadHandler = () => {
+    void ref.delete().catch(() => undefined);
+  };
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('beforeunload', unloadHandler);
+    window.addEventListener('pagehide', unloadHandler);
+  }
+
+  const cleanup = async () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('beforeunload', unloadHandler);
+      window.removeEventListener('pagehide', unloadHandler);
+    }
+    try {
+      await ref.delete();
+    } catch (error) {
+      // ignore cleanup failure
+    }
+  };
+
+  return { ref, cleanup, meta: { name, color, spawn } };
+}
+
+export async function leaveRoom(
+  roomCode: string,
+  uid: string,
+  handle?: EnterRoomHandle | null,
+): Promise<void> {
+  const ref = handle?.ref ?? getPlayerDoc(roomCode, uid);
+  if (handle) {
+    await handle.cleanup();
+    return;
+  }
+  try {
+    await ref.delete();
+  } catch (error) {
+    // ignore best-effort cleanup failure
+  }
+}
+
+export type { EnterRoomHandle };

--- a/src/net/renderRoom.ts
+++ b/src/net/renderRoom.ts
@@ -1,0 +1,112 @@
+import type { PlayerMap, PlayerPresence } from './playersStore';
+
+type RendererOptions = {
+  canvas: HTMLCanvasElement;
+  getPlayers: () => PlayerMap;
+  selfUid: string;
+};
+
+type StopRenderer = () => void;
+
+const STAGE_COLOR = '#fff';
+
+export function startRenderer(options: RendererOptions): StopRenderer {
+  const { canvas, getPlayers, selfUid } = options;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Canvas 2D context is not available.');
+  }
+  const width = canvas.width;
+  const height = canvas.height;
+  let rafId: number | null = null;
+
+  const drawStick = (player: PlayerPresence | undefined) => {
+    if (!player) {
+      return;
+    }
+    const x = Math.round(player.x);
+    const y = Math.round(player.y);
+    context.save();
+    context.translate(x, y);
+    context.strokeStyle = player.color || '#37A9FF';
+    context.lineWidth = player.uid === selfUid ? 3 : 2;
+
+    context.beginPath();
+    context.arc(0, -14, 6, 0, Math.PI * 2);
+    context.stroke();
+
+    context.beginPath();
+    context.moveTo(0, -8);
+    context.lineTo(0, 12);
+    context.stroke();
+
+    context.beginPath();
+    if (player.dir === 'R') {
+      context.moveTo(0, -2);
+      context.lineTo(10, 6);
+      context.moveTo(0, -2);
+      context.lineTo(-8, 4);
+    } else {
+      context.moveTo(0, -2);
+      context.lineTo(-10, 6);
+      context.moveTo(0, -2);
+      context.lineTo(8, 4);
+    }
+    context.stroke();
+
+    context.beginPath();
+    context.moveTo(0, 12);
+    context.lineTo(8, 22);
+    context.moveTo(0, 12);
+    context.lineTo(-8, 22);
+    context.stroke();
+
+    if (player.name) {
+      context.font = '10px system-ui';
+      context.textAlign = 'center';
+      context.fillStyle = '#fff';
+      context.fillText(player.name, 0, -24);
+    }
+
+    if (player.uid === selfUid) {
+      context.beginPath();
+      context.arc(0, 0, 18, 0, Math.PI * 2);
+      context.globalAlpha = 0.15;
+      context.fillStyle = '#fff';
+      context.fill();
+      context.globalAlpha = 1;
+    }
+
+    context.restore();
+  };
+
+  const drawFrame = () => {
+    context.clearRect(0, 0, width, height);
+    context.fillStyle = '#000';
+    context.fillRect(0, 0, width, height);
+    context.strokeStyle = STAGE_COLOR;
+    context.lineWidth = 2;
+    context.strokeRect(1, 1, width - 2, height - 2);
+
+    context.beginPath();
+    context.moveTo(0, height / 2);
+    context.lineTo(width, height / 2);
+    context.stroke();
+
+    const players = Array.from(getPlayers().values());
+    for (const player of players) {
+      drawStick(player);
+    }
+
+    rafId = requestAnimationFrame(drawFrame);
+  };
+
+  rafId = requestAnimationFrame(drawFrame);
+
+  return () => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+}

--- a/src/net/room.ts
+++ b/src/net/room.ts
@@ -1,0 +1,124 @@
+import { enterRoom, leaveRoom } from './presence';
+import { watchPlayers, type PlayerMap, type PlayerPresence } from './playersStore';
+import { attachControls } from './controls';
+import { startRenderer } from './renderRoom';
+
+type PresenceHandle = ReturnType<typeof enterRoom> extends Promise<infer R> ? R : never;
+
+export type RoomMountOptions = {
+  roomCode: string;
+  uid: string;
+  canvas: HTMLCanvasElement;
+  name?: string;
+  color?: string;
+  onPlayersChange?: (players: PlayerMap) => void;
+};
+
+export type RoomHandle = {
+  unmount: () => Promise<void>;
+};
+
+export async function mountRoom(options: RoomMountOptions): Promise<RoomHandle> {
+  const { roomCode, uid, canvas, name, color, onPlayersChange } = options;
+  const playersState: PlayerMap = new Map();
+
+  const notify = () => {
+    if (typeof onPlayersChange === 'function') {
+      onPlayersChange(new Map(playersState));
+    }
+  };
+
+  const getPlayers = () => playersState;
+  const getPlayer = (id: string) => playersState.get(id);
+  const setLocalPos = ({ x, y, dir }: { x: number; y: number; dir: 'L' | 'R' }) => {
+    const existing = playersState.get(uid);
+    const base: PlayerPresence = existing || {
+      uid,
+      name,
+      color,
+      x,
+      y,
+      dir,
+    };
+    playersState.set(uid, { ...base, x, y, dir });
+    notify();
+  };
+
+  let presenceHandle: PresenceHandle | null = null;
+  let unsubscribe: (() => void) | null = null;
+  let detachControls: (() => void) | null = null;
+  let stopRenderer: (() => void) | null = null;
+
+  try {
+    presenceHandle = await enterRoom(roomCode, uid, { name, color });
+    const { spawn } = presenceHandle.meta;
+    playersState.set(uid, {
+      uid,
+      name: presenceHandle.meta.name,
+      color: presenceHandle.meta.color,
+      x: spawn.x,
+      y: spawn.y,
+      dir: 'R',
+    });
+    notify();
+
+    unsubscribe = watchPlayers(roomCode, (map) => {
+      map.forEach((value, key) => {
+        if (key === uid) {
+          const local = playersState.get(uid);
+          if (local) {
+            playersState.set(uid, { ...value, x: local.x, y: local.y, dir: local.dir });
+          } else {
+            playersState.set(uid, value);
+          }
+        } else {
+          playersState.set(key, value);
+        }
+      });
+
+      Array.from(playersState.keys()).forEach((key) => {
+        if (!map.has(key)) {
+          playersState.delete(key);
+        }
+      });
+
+      notify();
+    });
+
+    detachControls = attachControls({ roomCode, uid, getPlayer, setLocalPos });
+    stopRenderer = startRenderer({ canvas, getPlayers, selfUid: uid });
+  } catch (error) {
+    if (detachControls) {
+      detachControls();
+    }
+    if (stopRenderer) {
+      stopRenderer();
+    }
+    if (unsubscribe) {
+      unsubscribe();
+    }
+    if (presenceHandle) {
+      try {
+        await leaveRoom(roomCode, uid, presenceHandle);
+      } catch (cleanupError) {
+        // ignore cleanup failure
+      }
+    }
+    throw error;
+  }
+
+  return {
+    unmount: async () => {
+      detachControls?.();
+      stopRenderer?.();
+      unsubscribe?.();
+      if (presenceHandle) {
+        try {
+          await leaveRoom(roomCode, uid, presenceHandle);
+        } catch (error) {
+          // ignore cleanup failure
+        }
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add Firestore compat helpers and presence management for room players
- render live stick figures with keyboard controls on the room canvas
- wire the room view to mount and clean up realtime presence with matching styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb8e74d64c832eba561d72ccfc9fbf