### PR TITLE
Align room state with shared canvas constants

### DIFF
--- a/src/constants/room.ts
+++ b/src/constants/room.ts
@@ -1,0 +1,4 @@
+export const CANVAS_W = 800;
+export const CANVAS_H = 440;
+export const STAGE_Y = CANVAS_H / 2;
+export const ROOM_PAD = 24;

--- a/src/net/renderRoom.ts
+++ b/src/net/renderRoom.ts
@@ -1,3 +1,4 @@
+import { CANVAS_H, CANVAS_W, STAGE_Y } from '../constants/room';
 import type { PlayerMap, PlayerPresence } from './playersStore';
 
 type RendererOptions = {
@@ -16,9 +17,16 @@ export function startRenderer(options: RendererOptions): StopRenderer {
   if (!context) {
     throw new Error('Canvas 2D context is not available.');
   }
-  const width = canvas.width;
-  const height = canvas.height;
+  const width = CANVAS_W;
+  const height = CANVAS_H;
+  if (canvas.width !== width) {
+    canvas.width = width;
+  }
+  if (canvas.height !== height) {
+    canvas.height = height;
+  }
   let rafId: number | null = null;
+  let lastLog = Number.NEGATIVE_INFINITY;
 
   const drawStick = (player: PlayerPresence | undefined) => {
     if (!player) {
@@ -89,11 +97,21 @@ export function startRenderer(options: RendererOptions): StopRenderer {
     context.strokeRect(1, 1, width - 2, height - 2);
 
     context.beginPath();
-    context.moveTo(0, height / 2);
-    context.lineTo(width, height / 2);
+    context.moveTo(0, STAGE_Y);
+    context.lineTo(width, STAGE_Y);
     context.stroke();
 
     const players = Array.from(getPlayers().values());
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    if (now - lastLog > 1000) {
+      console.log('[render] players', players.map((player) => ({
+        uid: player?.uid,
+        x: player?.x,
+        y: player?.y,
+        dir: player?.dir,
+      })));
+      lastLog = now;
+    }
     for (const player of players) {
       drawStick(player);
     }

--- a/src/net/room.ts
+++ b/src/net/room.ts
@@ -58,11 +58,11 @@ export async function mountRoom(options: RoomMountOptions): Promise<RoomHandle> 
       color: presenceHandle.meta.color,
       x: spawn.x,
       y: spawn.y,
-      dir: 'R',
+      dir: spawn.dir,
     });
     notify();
 
-    unsubscribe = watchPlayers(roomCode, (map) => {
+    unsubscribe = watchPlayers(roomCode, uid, (map) => {
       map.forEach((value, key) => {
         if (key === uid) {
           const local = playersState.get(uid);

--- a/src/ui/RoomView.tsx
+++ b/src/ui/RoomView.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { CANVAS_H, CANVAS_W } from '../constants/room';
 import MobileControls from './controls/MobileControls';
 import { claimPlayer, ERR_DEVICE_MISMATCH, HeartbeatHandle } from '../net/playerClaim';
 import { setLocalContext, clearLocalContext } from '../net/send';
@@ -208,7 +209,7 @@ export default function RoomView({ roomId, nick, children }: RoomViewProps) {
     <div className="room-view ready">
       <section data-view="room" id="view-room">
         <div className="room-wrap">
-          <canvas className="room-canvas" width={800} height={440} ref={canvasRef} />
+          <canvas className="room-canvas" width={CANVAS_W} height={CANVAS_H} ref={canvasRef} />
           <div className="room-stage-line" />
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add shared room constants for canvas dimensions, stage line height, and spawn padding
- spawn players along the stage midline and log room entry events
- keep self presence during initial empty snapshots and log render targets once a second
- ensure the room canvas uses the shared dimensions everywhere

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb969bc45c832ea01e2ed431de37ad