### PR TITLE
Make stage line red

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -80,7 +80,7 @@
         left: 0;
         right: 0;
         height: 0;
-        border-top: 2px solid #fff;
+        border-top: 2px solid #ff2a2a;
         pointer-events: none;
         opacity: 0.9;
         transform: translateY(-1px);
@@ -91,7 +91,7 @@
         top: 50%;
         left: 0;
         right: 0;
-        border-top: 2px solid #fff;
+        border-top: 2px solid #ff2a2a;
         opacity: 0.85;
         pointer-events: none;
         transform: translateY(-1px);

--- a/public/main.js
+++ b/public/main.js
@@ -3596,7 +3596,7 @@ this.teardownNetworking && this.teardownNetworking();
       if (stageLine) {
         stageLine.setVisible(true);
         stageLine.setDepth(1000);
-        stageLine.lineStyle(2, 0xffffff, 1);
+        stageLine.lineStyle(2, 0xff2a2a, 1);
         const midY = play.y + play.h / 2;
         stageLine.beginPath();
         stageLine.moveTo(play.x, midY);


### PR DESCRIPTION
## Summary
- update the renderer to draw the stage line in red instead of white
- adjust the CSS stage line styles to use the same red border color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb9a5c0910832ebe739a9702e13e37