### PR TITLE
Seed local player presence immediately

### DIFF
--- a/src/net/presence.ts
+++ b/src/net/presence.ts
@@ -12,10 +12,20 @@ type SpawnPoint = {
   dir: 'L' | 'R';
 };
 
+type SpawnPayload = {
+  uid: string;
+  name: string;
+  color: string;
+  x: number;
+  y: number;
+  dir: 'L' | 'R';
+  ts: unknown;
+};
+
 type EnterRoomHandle = {
   ref: ReturnType<typeof getPlayerDoc>;
   cleanup: () => Promise<void>;
-  meta: { name: string; color: string; spawn: SpawnPoint };
+  payload: SpawnPayload;
 };
 
 const HEARTBEAT_INTERVAL_MS = 15000;
@@ -46,7 +56,7 @@ export async function enterRoom(
   const color = typeof options.color === 'string' && options.color.trim() ? options.color : randomColor();
   const name = typeof options.name === 'string' && options.name.trim() ? options.name : 'Player';
 
-  const payload = {
+  const payload: SpawnPayload = {
     uid,
     name,
     color,
@@ -107,7 +117,7 @@ export async function enterRoom(
     }
   };
 
-  return { ref, cleanup, meta: { name, color, spawn } };
+  return { ref, cleanup, payload };
 }
 
 export async function leaveRoom(

--- a/src/net/renderRoom.ts
+++ b/src/net/renderRoom.ts
@@ -36,8 +36,15 @@ export function startRenderer(options: RendererOptions): StopRenderer {
     const y = Math.round(player.y);
     context.save();
     context.translate(x, y);
-    context.strokeStyle = player.color || '#37A9FF';
+    context.strokeStyle = '#ffffff';
     context.lineWidth = player.uid === selfUid ? 3 : 2;
+
+    context.beginPath();
+    context.moveTo(-2, 0);
+    context.lineTo(2, 0);
+    context.moveTo(0, -2);
+    context.lineTo(0, 2);
+    context.stroke();
 
     context.beginPath();
     context.arc(0, -14, 6, 0, Math.PI * 2);

--- a/src/net/room.ts
+++ b/src/net/room.ts
@@ -51,15 +51,8 @@ export async function mountRoom(options: RoomMountOptions): Promise<RoomHandle> 
 
   try {
     presenceHandle = await enterRoom(roomCode, uid, { name, color });
-    const { spawn } = presenceHandle.meta;
-    playersState.set(uid, {
-      uid,
-      name: presenceHandle.meta.name,
-      color: presenceHandle.meta.color,
-      x: spawn.x,
-      y: spawn.y,
-      dir: spawn.dir,
-    });
+    const { payload } = presenceHandle;
+    playersState.set(uid, { ...payload });
     notify();
 
     unsubscribe = watchPlayers(roomCode, uid, (map) => {


### PR DESCRIPTION
## Summary
- expose the spawn payload from `enterRoom` so callers can initialize their local presence immediately
- seed the local player map in `mountRoom` using the returned payload before Firestore snapshots arrive
- render players with a temporary white stroke and crosshair to keep them visible during debugging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9a9605d8832e95cd2407f4deb227