### PR TITLE
Add local room player utilities

### DIFF
--- a/src/room/PlayerTypes.ts
+++ b/src/room/PlayerTypes.ts
@@ -1,0 +1,12 @@
+export type Direction = 'L' | 'R';
+
+export type Player = {
+  uid: string;
+  name: string;
+  color: string;
+  x: number;
+  y: number;
+  dir: Direction;
+};
+
+export type PlayerMap = Map<string, Player>;

--- a/src/room/localSpawn.ts
+++ b/src/room/localSpawn.ts
@@ -1,0 +1,18 @@
+import { CANVAS_W, ROOM_PAD, STAGE_Y } from '../constants/room';
+import type { Direction, Player } from './PlayerTypes';
+
+type SpawnPoint = Pick<Player, 'x' | 'y' | 'dir'>;
+
+const DEFAULT_DIRECTION: Direction = 'R';
+
+export function spawnOnStage(): SpawnPoint {
+  const minX = ROOM_PAD;
+  const maxX = CANVAS_W - ROOM_PAD;
+  const x = Math.round(minX + Math.random() * Math.max(0, maxX - minX));
+
+  return {
+    x,
+    y: STAGE_Y,
+    dir: DEFAULT_DIRECTION,
+  };
+}

--- a/src/room/presence.ts
+++ b/src/room/presence.ts
@@ -1,0 +1,189 @@
+import type { Player, PlayerMap } from './PlayerTypes';
+
+type FirebaseNamespace = {
+  firestore?: () => FirebaseFirestore;
+};
+
+type FirebaseFirestore = {
+  doc: (path: string) => FirebaseDocRef;
+  collection: (path: string) => FirebaseCollectionRef;
+};
+
+type FirebaseDocRef = {
+  set?: (data: unknown, options?: Record<string, unknown>) => Promise<unknown>;
+  update?: (data: unknown) => Promise<unknown>;
+  delete?: () => Promise<unknown>;
+};
+
+type FirebaseCollectionRef = {
+  onSnapshot?: (callback: (snapshot: unknown) => unknown) => () => void;
+};
+
+type PresenceOptions = {
+  roomCode: string;
+  selfUid: string;
+  players: PlayerMap;
+  getLocalPlayer: () => Player | undefined;
+};
+
+type PresenceHandle = {
+  updateSelf: (player: Player) => Promise<void>;
+  stop: () => void;
+};
+
+type SnapshotDoc = {
+  id: string;
+  data: () => unknown;
+};
+
+type QuerySnapshot = {
+  empty?: boolean;
+  docs?: SnapshotDoc[];
+  forEach?: (callback: (doc: SnapshotDoc) => void) => void;
+};
+
+function getFirebase(): FirebaseFirestore | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const firebase = (window as unknown as { firebase?: FirebaseNamespace }).firebase;
+  if (!firebase || typeof firebase.firestore !== 'function') {
+    return null;
+  }
+  try {
+    const firestore = firebase.firestore();
+    if (firestore && typeof firestore.doc === 'function' && typeof firestore.collection === 'function') {
+      return firestore;
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
+function parsePlayer(uid: string, raw: unknown): Player | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const data = raw as Record<string, unknown>;
+  const name = typeof data.name === 'string' ? data.name : '';
+  const color = typeof data.color === 'string' ? data.color : '#ffffff';
+  const x = typeof data.x === 'number' && Number.isFinite(data.x) ? data.x : 0;
+  const y = typeof data.y === 'number' && Number.isFinite(data.y) ? data.y : 0;
+  const dirValue = data.dir === 'L' || data.dir === 'R' ? data.dir : 'R';
+
+  return {
+    uid,
+    name,
+    color,
+    x,
+    y,
+    dir: dirValue,
+  };
+}
+
+function handleSnapshot(
+  snapshot: QuerySnapshot,
+  options: { players: PlayerMap; selfUid: string },
+): void {
+  const { players, selfUid } = options;
+  const seen = new Set<string>();
+
+  const consumeDoc = (doc: SnapshotDoc) => {
+    if (!doc || typeof doc.id !== 'string' || typeof doc.data !== 'function') {
+      return;
+    }
+    const payload = parsePlayer(doc.id, doc.data());
+    if (!payload) {
+      return;
+    }
+    seen.add(payload.uid);
+    if (payload.uid === selfUid) {
+      const local = players.get(selfUid);
+      players.set(selfUid, local ?? payload);
+      return;
+    }
+    players.set(payload.uid, payload);
+  };
+
+  if (snapshot.forEach) {
+    snapshot.forEach(consumeDoc);
+  } else if (Array.isArray(snapshot.docs)) {
+    for (const doc of snapshot.docs) {
+      consumeDoc(doc);
+    }
+  }
+
+  for (const uid of Array.from(players.keys())) {
+    if (uid === selfUid) {
+      continue;
+    }
+    if (!seen.has(uid)) {
+      players.delete(uid);
+    }
+  }
+}
+
+const NOOP_HANDLE: PresenceHandle = {
+  updateSelf: async () => {
+    // no-op when Firebase is unavailable
+  },
+  stop: () => {
+    // nothing to clean up
+  },
+};
+
+export function startPresence(options: PresenceOptions): PresenceHandle {
+  const { roomCode, selfUid, players, getLocalPlayer } = options;
+  const firestore = getFirebase();
+  if (!firestore) {
+    return NOOP_HANDLE;
+  }
+
+  const docRef = firestore.doc(`rooms/${roomCode}/players/${selfUid}`) as FirebaseDocRef;
+  const collectionRef = firestore.collection(`rooms/${roomCode}/players`) as FirebaseCollectionRef;
+
+  const localPlayer = getLocalPlayer();
+  if (localPlayer && typeof docRef.set === 'function') {
+    void docRef.set(localPlayer, { merge: true }).catch(() => undefined);
+  }
+
+  players.set(selfUid, localPlayer ?? players.get(selfUid) ?? {
+    uid: selfUid,
+    name: '',
+    color: '#ffffff',
+    x: 0,
+    y: 0,
+    dir: 'R',
+  });
+
+  let unsubscribe: (() => void) | null = null;
+  if (collectionRef && typeof collectionRef.onSnapshot === 'function') {
+    unsubscribe = collectionRef.onSnapshot((snapshot: unknown) => {
+      if (!snapshot || typeof snapshot !== 'object') {
+        return;
+      }
+      handleSnapshot(snapshot as QuerySnapshot, { players, selfUid });
+    });
+  }
+
+  const updateSelf = async (player: Player) => {
+    players.set(selfUid, player);
+    if (docRef && typeof docRef.set === 'function') {
+      try {
+        await docRef.set(player, { merge: true });
+      } catch (error) {
+        // best-effort update
+      }
+    }
+  };
+
+  const stop = () => {
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+  };
+
+  return { updateSelf, stop };
+}

--- a/src/room/renderer.ts
+++ b/src/room/renderer.ts
@@ -1,0 +1,142 @@
+import { CANVAS_H, CANVAS_W, STAGE_Y } from '../constants/room';
+import type { Player, PlayerMap } from './PlayerTypes';
+
+type RendererOptions = {
+  canvas: HTMLCanvasElement;
+  getPlayers: () => PlayerMap;
+  selfUid?: string | null;
+};
+
+type StopRenderer = () => void;
+
+const BACKGROUND_COLOR = '#000000';
+const BORDER_COLOR = '#ffffff';
+const MIDLINE_COLOR = '#ff2a2a';
+const NAME_FILL = '#ffffff';
+
+const HEAD_RADIUS = 10;
+const BODY_HEIGHT = 32;
+const ARM_LENGTH = 18;
+const LEG_LENGTH = 18;
+
+function ensureCanvasSize(canvas: HTMLCanvasElement): void {
+  if (canvas.width !== CANVAS_W) {
+    canvas.width = CANVAS_W;
+  }
+  if (canvas.height !== CANVAS_H) {
+    canvas.height = CANVAS_H;
+  }
+}
+
+function drawStickFigure(
+  context: CanvasRenderingContext2D,
+  player: Player,
+  isSelf: boolean,
+): void {
+  context.save();
+  context.translate(Math.round(player.x), Math.round(player.y));
+  context.lineWidth = isSelf ? 4 : 2;
+  context.strokeStyle = player.color || '#ffffff';
+  context.lineCap = 'round';
+  context.lineJoin = 'round';
+
+  // Body
+  context.beginPath();
+  context.moveTo(0, -BODY_HEIGHT);
+  context.lineTo(0, 0);
+  context.stroke();
+
+  // Head
+  context.beginPath();
+  context.arc(0, -BODY_HEIGHT - HEAD_RADIUS, HEAD_RADIUS, 0, Math.PI * 2);
+  context.stroke();
+
+  // Arms
+  context.beginPath();
+  if (player.dir === 'L') {
+    context.moveTo(0, -BODY_HEIGHT + HEAD_RADIUS);
+    context.lineTo(-ARM_LENGTH, -BODY_HEIGHT + HEAD_RADIUS + 6);
+    context.moveTo(0, -BODY_HEIGHT + HEAD_RADIUS);
+    context.lineTo(ARM_LENGTH * 0.4, -BODY_HEIGHT + HEAD_RADIUS + 4);
+  } else {
+    context.moveTo(0, -BODY_HEIGHT + HEAD_RADIUS);
+    context.lineTo(ARM_LENGTH, -BODY_HEIGHT + HEAD_RADIUS + 6);
+    context.moveTo(0, -BODY_HEIGHT + HEAD_RADIUS);
+    context.lineTo(-ARM_LENGTH * 0.4, -BODY_HEIGHT + HEAD_RADIUS + 4);
+  }
+  context.stroke();
+
+  // Legs
+  context.beginPath();
+  context.moveTo(0, 0);
+  context.lineTo(-LEG_LENGTH, LEG_LENGTH);
+  context.moveTo(0, 0);
+  context.lineTo(LEG_LENGTH, LEG_LENGTH);
+  context.stroke();
+
+  if (player.name) {
+    context.font = '12px system-ui, sans-serif';
+    context.textAlign = 'center';
+    context.fillStyle = NAME_FILL;
+    context.fillText(player.name, 0, -BODY_HEIGHT - HEAD_RADIUS - 10);
+  }
+
+  if (isSelf) {
+    context.globalAlpha = 0.2;
+    context.beginPath();
+    context.arc(0, 0, LEG_LENGTH + 6, 0, Math.PI * 2);
+    context.fillStyle = player.color || '#ffffff';
+    context.fill();
+    context.globalAlpha = 1;
+  }
+
+  context.restore();
+}
+
+function drawStage(context: CanvasRenderingContext2D): void {
+  context.fillStyle = BACKGROUND_COLOR;
+  context.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  context.strokeStyle = BORDER_COLOR;
+  context.lineWidth = 2;
+  context.strokeRect(1, 1, CANVAS_W - 2, CANVAS_H - 2);
+
+  context.strokeStyle = MIDLINE_COLOR;
+  context.lineWidth = 2;
+  context.beginPath();
+  context.moveTo(0, STAGE_Y);
+  context.lineTo(CANVAS_W, STAGE_Y);
+  context.stroke();
+}
+
+export function startRenderer(options: RendererOptions): StopRenderer {
+  const { canvas, getPlayers, selfUid = null } = options;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Canvas 2D context is not available.');
+  }
+
+  ensureCanvasSize(canvas);
+
+  let rafId: number | null = null;
+
+  const renderFrame = () => {
+    drawStage(context);
+
+    const players = getPlayers();
+    for (const player of players.values()) {
+      drawStickFigure(context, player, player.uid === selfUid);
+    }
+
+    rafId = window.requestAnimationFrame(renderFrame);
+  };
+
+  rafId = window.requestAnimationFrame(renderFrame);
+
+  return () => {
+    if (rafId !== null) {
+      window.cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- define shared player types and stage spawn helper for room features
- add canvas renderer for room stick figures and arena decorations
- provide optional Firebase-backed presence syncing for room players

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc37672194832e80d9111d0cc5d604