### PR TITLE
Disable automatic lobby join from query params

### DIFF
--- a/public/net.js
+++ b/public/net.js
@@ -28,6 +28,9 @@
   const bootFlags = Boot && Boot.flags ? Boot.flags : { debug: false, safe: false, nofs: false, nolobby: false };
   const NETWORK_DISABLED = !!(bootFlags.safe || bootFlags.nolobby);
 
+  const AUTO_JOIN_FROM_QUERY = false;
+  const AUTO_JOIN_FROM_STATE = false;
+
   if (NETWORK_DISABLED) {
     bootLog('ROUTE', 'net-module-disabled', { safe: bootFlags.safe, nolobby: bootFlags.nolobby });
   }
@@ -3197,7 +3200,11 @@ await withFirestoreErrorHandling('listen', async () => {
     setupRouter(initialRoute || '#/lobby');
 
     if (safeRoomId) {
-      joinLobbyByCode(safeRoomId);
+      if (AUTO_JOIN_FROM_QUERY) {
+        joinLobbyByCode(safeRoomId);
+      } else {
+        ensureLobbyView();
+      }
     } else if (roomId) {
       ensureLobbyView();
       setBannerMessage(


### PR DESCRIPTION
## Summary
- add feature flags for automatically joining a lobby from persisted state or query parameters
- guard the query parameter auto-join to render the lobby unless explicitly enabled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc5b26c350832ea95db541bf10c46a